### PR TITLE
Fixed src_img local variable clobber

### DIFF
--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -276,12 +276,12 @@ class Segmentation(SOPClass):
         # General Reference
         self.SourceImageSequence = []
         referenced_series = defaultdict(list)
-        for src_img in self._source_images:
+        for s_img in self._source_images:
             ref = Dataset()
-            ref.ReferencedSOPClassUID = src_img.SOPClassUID
-            ref.ReferencedSOPInstanceUID = src_img.SOPInstanceUID
+            ref.ReferencedSOPClassUID = s_img.SOPClassUID
+            ref.ReferencedSOPInstanceUID = s_img.SOPInstanceUID
             self.SourceImageSequence.append(ref)
-            referenced_series[src_img.SeriesInstanceUID].append(ref)
+            referenced_series[s_img.SeriesInstanceUID].append(ref)
 
         # Common Instance Reference
         self.ReferencedSeriesSequence = []


### PR DESCRIPTION
Minor fix where the `src_img` loop variable clobbered the local variable `src_img`, meaning that before the loop `src_img` refers to the first source image, and after the loop it refers to the last.

I don't think this caused any particular problems, but I assume it was not intended and is a potential gotcha for future maintenance.

Fix is simply to change the loop variable name to `s_img`