### PR TITLE
Enforce positive series and instance numbers

### DIFF
--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -172,6 +172,10 @@ class SOPClass(Dataset):
 
         # Series
         self.SeriesInstanceUID = str(series_instance_uid)
+        if series_number < 1:
+            raise ValueError(
+                '"series_number" should be a positive integer.'
+            )
         self.SeriesNumber = series_number
         self.Modality = modality
         if series_description is not None:
@@ -183,6 +187,10 @@ class SOPClass(Dataset):
         # Instance
         self.SOPInstanceUID = str(sop_instance_uid)
         self.SOPClassUID = str(sop_class_uid)
+        if instance_number < 1:
+            raise ValueError(
+                '"instance_number" should be a positive integer.'
+            )
         self.InstanceNumber = instance_number
         self.ContentDate = DA(datetime.datetime.now().date())
         self.ContentTime = TM(datetime.datetime.now().time())

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -30,8 +30,8 @@ class TestLegacyConvertedEnhancedImage(unittest.TestCase):
             self.generate_common_dicom_dataset_series(3, Modality.PT)
         self._output_series_instance_uid = generate_uid()
         self._output_sop_instance_uid = generate_uid()
-        self._output_series_number = '1'
-        self._output_instance_number = '1'
+        self._output_series_number = 1
+        self._output_instance_number = 1
 
     def test_output_attributes(self):
         for m in self._modalities:

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -26,8 +26,8 @@ class TestSCImage(unittest.TestCase):
         self._study_instance_uid = UID()
         self._series_instance_uid = UID()
         self._sop_instance_uid = UID()
-        self._series_number = int(np.random.choice(100))
-        self._instance_number = int(np.random.choice(100))
+        self._series_number = int(np.random.choice(100)) + 1
+        self._instance_number = int(np.random.choice(100)) + 1
         self._manufacturer = 'ABC'
         self._laterality = 'L'
         self._patient_orientation = ['A', 'R']


### PR DESCRIPTION
As discussed in #125, we are a little uncertain about the requirements on instance numbers. This PR adds checks to enforce that all instance and series numbers are positive integers. This may be somewhat opinionated.

Do you think we should add these checks @hackermd ?