### PR TITLE
Allow SR content parameter to be single element sequence

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -279,7 +279,7 @@ image:
     # Create the Structured Report instance
     sr_dataset = hd.sr.Comprehensive3DSR(
         evidence=[image_dataset],
-        content=measurement_report[0],
+        content=measurement_report,
         series_number=1,
         series_instance_uid=hd.UID(),
         sop_instance_uid=hd.UID(),

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -3639,12 +3639,27 @@ class TestEnhancedSR(unittest.TestCase):
             observation_context=observation_context,
             procedure_reported=codes.LN.CTUnspecifiedBodyRegion,
             imaging_measurements=imaging_measurements
-        )[0]
+        )
 
     def test_construction(self):
         report = EnhancedSR(
             evidence=[self._ref_dataset],
-            content=self._content,
+            content=self._content[0],
+            series_instance_uid=self._series_instance_uid,
+            series_number=self._series_number,
+            sop_instance_uid=self._sop_instance_uid,
+            instance_number=self._instance_number,
+            institution_name=self._institution_name,
+            institutional_department_name=self._department_name,
+            manufacturer=self._manufacturer,
+            performed_procedure_codes=self._performed_procedures
+        )
+        assert report.SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.22'
+
+    def test_construction_content_is_sequence(self):
+        report = EnhancedSR(
+            evidence=[self._ref_dataset],
+            content=self._content,  # the full measurement report
             series_instance_uid=self._series_instance_uid,
             series_number=self._series_number,
             sop_instance_uid=self._sop_instance_uid,
@@ -3759,9 +3774,29 @@ class TestComprehensiveSR(unittest.TestCase):
             observation_context=self._observation_context,
             procedure_reported=self._procedure_reported,
             imaging_measurements=self._imaging_measurements
-        )[0]
+        )
 
     def test_construction(self):
+        report = ComprehensiveSR(
+            evidence=[self._ref_dataset],
+            content=self._content[0],
+            series_instance_uid=self._series_instance_uid,
+            series_number=self._series_number,
+            sop_instance_uid=self._sop_instance_uid,
+            instance_number=self._instance_number,
+            institution_name=self._institution_name,
+            institutional_department_name=self._department_name,
+            manufacturer=self._manufacturer,
+            performed_procedure_codes=self._performed_procedures,
+        )
+        assert report.SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.33'
+
+        ref_evd_items = report.CurrentRequestedProcedureEvidenceSequence
+        assert len(ref_evd_items) == 1
+        with pytest.raises(AttributeError):
+            assert report.PertinentOtherEvidenceSequence
+
+    def test_construction_content_is_sequence(self):
         report = ComprehensiveSR(
             evidence=[self._ref_dataset],
             content=self._content,
@@ -3965,9 +4000,41 @@ class TestComprehensive3DSR(unittest.TestCase):
             observation_context=observation_context,
             procedure_reported=codes.LN.CTUnspecifiedBodyRegion,
             imaging_measurements=imaging_measurements
-        )[0]
+        )
 
     def test_construction(self):
+        report = Comprehensive3DSR(
+            evidence=[self._ref_dataset],
+            content=self._content[0],
+            series_instance_uid=self._series_instance_uid,
+            series_number=self._series_number,
+            sop_instance_uid=self._sop_instance_uid,
+            instance_number=self._instance_number,
+            institution_name=self._institution_name,
+            institutional_department_name=self._department_name,
+            manufacturer=self._manufacturer,
+            performed_procedure_codes=self._performed_procedures,
+        )
+        assert report.SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.34'
+        assert report.PatientID == self._ref_dataset.PatientID
+        assert report.PatientName == self._ref_dataset.PatientName
+        assert report.StudyInstanceUID == self._ref_dataset.StudyInstanceUID
+        assert report.AccessionNumber == self._ref_dataset.AccessionNumber
+        assert report.SeriesInstanceUID == self._series_instance_uid
+        assert report.SeriesNumber == self._series_number
+        assert report.SOPInstanceUID == self._sop_instance_uid
+        assert report.InstanceNumber == self._instance_number
+        assert report.SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.34'
+        assert report.InstitutionName == self._institution_name
+        assert report.Manufacturer == self._manufacturer
+        assert report.Modality == 'SR'
+
+        with pytest.raises(AttributeError):
+            assert report.CurrentRequestedProcedureEvidenceSequence
+        unref_evd_items = report.PertinentOtherEvidenceSequence
+        assert len(unref_evd_items) == 1
+
+    def test_construction_content_is_sequence(self):
         report = Comprehensive3DSR(
             evidence=[self._ref_dataset],
             content=self._content,


### PR DESCRIPTION
We discussed a while ago using that forcing users to manually pass the first element of a the content sequence (such as a `highdicom.sr.MeasurementReport` object) when constructing an SR object is clumsy and counterintuitive.

This PR allows the user to pass any content sequence that contains a single item to the `content` parameter of the SR classes, and tweaks the user guide to make this the official recommendation. The old way of passing a dataset is also supported. 