### PR TITLE
Fix ReferenceImageSequence

### DIFF
--- a/src/highdicom/ann/sop.py
+++ b/src/highdicom/ann/sop.py
@@ -188,13 +188,12 @@ class MicroscopyBulkSimpleAnnotations(SOPClass):
                 'value.'
             )
 
+        # Common Instance Reference
         ref = Dataset()
         ref.ReferencedSOPClassUID = src_img.SOPClassUID
         ref.ReferencedSOPInstanceUID = src_img.SOPInstanceUID
         self.ReferencedImageSequence = [ref]
 
-        # Common Instance Reference
-        self.ReferencedImageSequence: List[Dataset] = []
         referenced_series: Dict[str, List[Dataset]] = defaultdict(list)
         for img in source_images:
             ref = Dataset()


### PR DESCRIPTION
In the bulk microscopy annotations module, the ReferencedImageSequence is always set to an empty list, which is disallowed by the standard. This appears to be a simple typo/bug with a simple fix