### PR TITLE
Refactor check for described segments to remove unnecessary copies

### DIFF
--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -1040,9 +1040,8 @@ class Segmentation(SOPClass):
             if pixel_array.ndim == 3:
                 # A label-map style array where pixel values represent
                 # segment associations
-                segments_present = np.unique(
-                    pixel_array[pixel_array > 0].astype(np.uint16)
-                )
+                segments_present = np.unique(pixel_array).astype(np.uint16)
+                segments_present = segments_present[segments_present > 0]
 
                 # The pixel values in the pixel array must all belong to
                 # a described segment


### PR DESCRIPTION
Memory utilization is high when constructing segmentations of large images (e.g. WSIs).

This is one simple two-line refactor to reduce memory consumption that I spotted: the current code creates a copy of all non-zero pixels the input array cast to uint16 (which may be double the input array size) just to find the list of unique segments.

Haven't actually evaluated the effect on memory usage (this may not be the limiting factor) but it's so obviously unnecessary that I just fixed it anyway.