### PR TITLE
Handle DicomFileLike

### DIFF
--- a/src/highdicom/io.py
+++ b/src/highdicom/io.py
@@ -241,7 +241,7 @@ class ImageFileReader(object):
 
     """
 
-    def __init__(self, filename: Union[str, Path, DicomFileLike, DicomBytesIO]):
+    def __init__(self, filename: Union[str, Path, DicomFileLike]):
         """
         Parameters
         ----------
@@ -251,11 +251,10 @@ class ImageFileReader(object):
         """
         if isinstance(filename, DicomFileLike):
             fp = filename
+            self._fp = fp
             if isinstance(filename, DicomBytesIO):
-                self._fp = filename
                 self._filename = None
             else:
-                self._fp = fp
                 self._filename = Path(fp.name)
         elif isinstance(filename, (str, Path)):
             self._filename = Path(filename)
@@ -326,7 +325,7 @@ class ImageFileReader(object):
 
     def _check_file_format(
             self,
-            fp: Union[DicomFileLike, DicomBytesIO]
+            fp: DicomFileLike
     ) -> Tuple[bool, bool]:
         """Check whether file object represents a DICOM Part 10 file.
 

--- a/src/highdicom/io.py
+++ b/src/highdicom/io.py
@@ -324,7 +324,10 @@ class ImageFileReader(object):
         self._fp.is_little_endian = is_little_endian
         self._fp.is_implicit_VR = is_implicit_VR
 
-    def _check_file_format(self, fp: Union[DicomFileLike, DicomBytesIO]) -> Tuple[bool, bool]:
+    def _check_file_format(
+            self,
+            fp: Union[DicomFileLike, DicomBytesIO]
+    ) -> Tuple[bool, bool]:
         """Check whether file object represents a DICOM Part 10 file.
 
         Parameters

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,12 +5,12 @@ from random import shuffle
 import numpy as np
 from pydicom import dcmread
 from pydicom.data import get_testdata_file
+from pydicom.filebase import DicomBytesIO
 
 from highdicom.io import ImageFileReader
 
 
 class TestImageFileReader(unittest.TestCase):
-
     def setUp(self):
         super().setUp()
         file_path = Path(__file__)
@@ -156,3 +156,21 @@ class TestImageFileReader(unittest.TestCase):
                     reader.metadata.Columns,
                 )
                 np.testing.assert_array_equal(frame, pixel_array[i, ...])
+
+    def test_read_single_frame_ct_image_dicom_file_like(self):
+        filename = str(self._test_dir.joinpath("ct_image.dcm"))
+        dcm = DicomBytesIO(open(filename, "rb").read())
+
+        dataset = dcmread(filename)
+        pixel_array = dataset.pixel_array
+        with ImageFileReader(dcm) as reader:
+            assert reader.number_of_frames == 1
+            frame = reader.read_frame(0)
+            assert isinstance(frame, np.ndarray)
+            assert frame.ndim == 2
+            assert frame.dtype == np.int16
+            assert frame.shape == (
+                reader.metadata.Rows,
+                reader.metadata.Columns,
+            )
+            np.testing.assert_array_equal(frame, pixel_array)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,7 +5,7 @@ from random import shuffle
 import numpy as np
 from pydicom import dcmread
 from pydicom.data import get_testdata_file
-from pydicom.filebase import DicomBytesIO
+from pydicom.filebase import DicomBytesIO, DicomFileLike
 
 from highdicom.io import ImageFileReader
 
@@ -157,7 +157,7 @@ class TestImageFileReader(unittest.TestCase):
                 )
                 np.testing.assert_array_equal(frame, pixel_array[i, ...])
 
-    def test_read_single_frame_ct_image_dicom_file_like(self):
+    def test_read_single_frame_ct_image_dicom_bytes_io(self):
         filename = str(self._test_dir.joinpath("ct_image.dcm"))
         dcm = DicomBytesIO(open(filename, "rb").read())
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -174,7 +174,7 @@ class TestImageFileReader(unittest.TestCase):
                 reader.metadata.Columns,
             )
             np.testing.assert_array_equal(frame, pixel_array)
-            
+
     def test_read_single_frame_ct_image_dicom_file_like_opened(self):
         # Test reading frames from an opened DicomFileLike file
         filename = self._test_dir.joinpath("ct_image.dcm")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -174,3 +174,22 @@ class TestImageFileReader(unittest.TestCase):
                 reader.metadata.Columns,
             )
             np.testing.assert_array_equal(frame, pixel_array)
+            
+    def test_read_single_frame_ct_image_dicom_file_like_opened(self):
+        # Test reading frames from an opened DicomFileLike file
+        filename = self._test_dir.joinpath("ct_image.dcm")
+        dcm = DicomFileLike(filename.open("rb"))
+
+        dataset = dcmread(filename)
+        pixel_array = dataset.pixel_array
+        with ImageFileReader(dcm) as reader:
+            assert reader.number_of_frames == 1
+            frame = reader.read_frame(0)
+            assert isinstance(frame, np.ndarray)
+            assert frame.ndim == 2
+            assert frame.dtype == np.int16
+            assert frame.shape == (
+                reader.metadata.Rows,
+                reader.metadata.Columns,
+            )
+            np.testing.assert_array_equal(frame, pixel_array)


### PR DESCRIPTION
Fixes https://github.com/ImagingDataCommons/highdicom/issues/222

Not sure about the expected behavior of `_check_file_format` as `fp` wasn't even used.