### PR TITLE
Exclude incompatible pydicom 2.4.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
     package_dir={'': 'src'},
     python_requires='>=3.6',
     install_requires=[
-        'pydicom>=2.3.0',
+        'pydicom>=2.3.0,!=2.4.0',
         'numpy>=1.19',
         'pillow>=8.3',
         'pillow-jpls>=1.0',


### PR DESCRIPTION
Pydicom 2.4.0 is essentially incompatible with highdicom, see #233 and https://github.com/pydicom/pydicom/issues/1813

The fix introduced in https://github.com/pydicom/pydicom/pulls/1814 and was released in pydicom 2.4.1. We should therefore exclude the specific problematic version of pydicom (2.4.0) in our setup.py.