### PR TITLE
Fixes to various VRs flagged by tests

### DIFF
--- a/src/highdicom/pm/sop.py
+++ b/src/highdicom/pm/sop.py
@@ -737,9 +737,11 @@ class ParametricMap(SOPClass):
                 # Frame Content
                 frame_content_item = Dataset()
                 frame_content_item.DimensionIndexValues = [
-                    np.where(
-                        (dimension_position_values[idx] == pos)
-                    )[0][0] + 1
+                    int(
+                        np.where(
+                            (dimension_position_values[idx] == pos)
+                        )[0][0] + 1
+                    )
                     for idx, pos in enumerate(plane_position_values[i])
                 ]
 

--- a/src/highdicom/pr/content.py
+++ b/src/highdicom/pr/content.py
@@ -431,7 +431,7 @@ class TextObject(Dataset):
                 raise ValueError(
                     'All coordinates in the bounding box must be non-negative.'
                 )
-            self.AnchorPoint = anchor_point
+            self.AnchorPoint = list(anchor_point)
             self.AnchorPointAnnotationUnits = units.value
             self.AnchorPointVisibility = 'Y' if anchor_point_visible else 'N'
             if units == AnnotationUnitsValues.DISPLAY:

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -1612,9 +1612,11 @@ class Segmentation(SOPClass):
                             CoordinateSystemNames.SLIDE
                         ):
                             index_values = [
-                                np.where(
-                                    (dimension_position_values[idx] == pos)
-                                )[0][0] + 1
+                                int(
+                                    np.where(
+                                        (dimension_position_values[idx] == pos)
+                                    )[0][0] + 1
+                                )
                                 for idx, pos in enumerate(
                                     plane_position_values[j]
                                 )
@@ -1625,11 +1627,12 @@ class Segmentation(SOPClass):
                             # Sequence points to (Image Position Patient) has a
                             # value multiplicity greater than one.
                             index_values = [
-                                np.where(
-                                    (dimension_position_values[idx] == pos).all(
-                                        axis=1
-                                    )
-                                )[0][0] + 1
+                                int(
+                                    np.where(
+                                        (dimension_position_values[idx] == pos)
+                                        .all(axis=1)
+                                    )[0][0] + 1
+                                )
                                 for idx, pos in enumerate(
                                     plane_position_values[j]
                                 )
@@ -1641,7 +1644,7 @@ class Segmentation(SOPClass):
                             'dimension index values: {}'.format(j, error)
                         )
                 frame_content_item.DimensionIndexValues = (
-                    [segment_number] + index_values
+                    [int(segment_number)] + index_values
                 )
                 pffp_item.FrameContentSequence = [frame_content_item]
                 if has_ref_frame_uid:
@@ -1696,7 +1699,7 @@ class Segmentation(SOPClass):
                     logger.warning('spatial locations not preserved')
 
                 identification = Dataset()
-                identification.ReferencedSegmentNumber = segment_number
+                identification.ReferencedSegmentNumber = int(segment_number)
                 pffp_item.SegmentIdentificationSequence = [
                     identification,
                 ]


### PR DESCRIPTION
Pydicom 2.4.0 and 2.4.1 have stricter checks on value representations when `pydicom.config.enforce_valid_values` is `True` than previous versions of pydicom. Some of our code falls foul of these new checks and since we set `pydicom.config/enforce_valid_values=True` in our `conftest.py`, our tests are currently failing with `pydicom>=2.4.0`.

The type incompatibilities are related to either using a numpy integer type rather than a python built-in integer type, or using a tuple as a multivalue rather than a list.

This PR explicitly casts to appropriate types to fix all of the errors raised by our test suite.