### PR TITLE
work around pillow 10.0.0 changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
     install_requires=[
         'pydicom>=2.3.0,!=2.4.0',
         'numpy>=1.19',
-        'pillow>=8.3',
+        'pillow>=10.0.0',
         'pillow-jpls>=1.0',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
     install_requires=[
         'pydicom>=2.3.0,!=2.4.0',
         'numpy>=1.19',
-        'pillow>=10.0.0',
+        'pillow>=8.3',
         'pillow-jpls>=1.0',
     ],
     extras_require={

--- a/src/highdicom/color.py
+++ b/src/highdicom/color.py
@@ -145,7 +145,18 @@ class ColorManager(object):
         logger.debug(f'found ICC Profile "{name}": "{description}"')
 
         logger.debug('build ICC Transform')
-        intent = ImageCms.Intent.RELATIVE_COLORIMETRIC
+        if hasattr(ImageCms, "Intent"):
+            # This is the API for pillow>=10.0.0
+            intent = ImageCms.Intent.RELATIVE_COLORIMETRIC
+            direction = ImageCms.Direction.INPUT
+        else:
+            # This is the API for pillow<10.0.0
+            # Ideally we would simply require pillow>=10.0.0, but unfortunately
+            # this would rule out supporting python < 3.8. Once we drop support
+            # for 3.7 and below, we can require pillow>=10.0.0 and drop this
+            # branch
+            intent = ImageCms.INTENT_RELATIVE_COLORIMETRIC
+            direction = ImageCms.DIRECTION_INPUT
         if not isIntentSupported(
             profile,
             intent=intent,

--- a/src/highdicom/color.py
+++ b/src/highdicom/color.py
@@ -160,7 +160,7 @@ class ColorManager(object):
         if not isIntentSupported(
             profile,
             intent=intent,
-            direction=ImageCms.Direction.INPUT
+            direction=direction,
         ):
             raise ValueError(
                 'ICC Profile does not support desired '

--- a/src/highdicom/color.py
+++ b/src/highdicom/color.py
@@ -145,11 +145,11 @@ class ColorManager(object):
         logger.debug(f'found ICC Profile "{name}": "{description}"')
 
         logger.debug('build ICC Transform')
-        intent = ImageCms.INTENT_RELATIVE_COLORIMETRIC
+        intent = ImageCms.Intent.RELATIVE_COLORIMETRIC
         if not isIntentSupported(
             profile,
             intent=intent,
-            direction=ImageCms.DIRECTION_INPUT
+            direction=ImageCms.Direction.INPUT
         ):
             raise ValueError(
                 'ICC Profile does not support desired '


### PR DESCRIPTION
Fix for #243 :

- Require pillow >=10.0.0
- Update `highdicom.color` to use the new organisation of constants found in pillow==10.0.0