### PR TITLE
Multiprocessing for frame encoding in Segmentation constructor

### DIFF
--- a/docs/seg.rst
+++ b/docs/seg.rst
@@ -606,6 +606,21 @@ and 1):
 - The clear frame boundaries make retrieving individual frames from
   ``"FRACTIONAL"`` image files possible.
 
+Multiprocessing
+---------------
+
+When creating large, multiframe ``"FRACTIONAL"`` segmentations using a
+compressed transfer syntax, the time taken to compress the frames can become
+large and dominate the time taken to create the segmentation. By default,
+frames are compressed in series using the main process, however the ``workers``
+parameter allows you to specify a number of additional worker processes that
+will be used to compress frames in parallel. Setting ``workers`` to a negative
+number uses all available processes on your machine. Note that while this is
+likely to result in significantly lower creations times for segmentations with
+a very large number of frames, for segmentations with only a few frames the
+additional overhead of spawning processes may in fact slow the entire
+segmentation creation process down.
+
 Geometry of SEG Images
 ----------------------
 

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -2010,7 +2010,7 @@ class Segmentation(SOPClass):
         segmentation_type: SegmentationTypeValues,
         max_fractional_value: int
     ) -> np.ndarray:
-        """Get pixel data array for a specific segment.
+        """Get pixel data array for a specific segment and plane.
 
         This is a helper method used during the constructor. Note that the
         pixel array is expected to have been processed using the
@@ -2020,9 +2020,9 @@ class Segmentation(SOPClass):
         Parameters
         ----------
         pixel_array: numpy.ndarray
-            Full segmentation pixel array containing all segments for a single
-            plane. Array is therefore either (Rows x Columns x Segments) or
-            (Rows x Columns) in case of a "label map" style array.
+            Segmentation pixel array containing all segments for a single plane.
+            Array is therefore either (Rows x Columns x Segments) or (Rows x
+            Columns) in case of a "label map" style array.
         segment_number: int
             The segment of interest.
         number_of_segments: int
@@ -2036,8 +2036,8 @@ class Segmentation(SOPClass):
         -------
         numpy.ndarray:
             Pixel data array consisting of pixel data for a single segment for
-            all planes. Output array has dtype np.uint8 and binary values (0 or
-            1).
+            a single plane. Output array has dtype np.uint8 and binary values
+            (0 or 1).
 
         """
         if pixel_array.dtype in (np.float_, np.float32, np.float64):

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -1577,7 +1577,7 @@ class Segmentation(SOPClass):
                         # future to the list for encapsulation at the end
                         future = process_pool.submit(
                             encode_frame,
-                            array=segment_array[plane_index].copy(),
+                            array=segment_array[plane_index],
                             **encode_frame_kwargs,
                         )
                         frame_futures_list.append(future)

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor
 from copy import deepcopy
 import unittest
 from pathlib import Path
@@ -1408,9 +1409,10 @@ class TestSegmentation:
             SegmentsOverlapValues.NO
 
     def test_construction_workers(self):
+        # Create a segmentation with multiple workers
         instance = Segmentation(
-            [self._ct_image],
-            self._ct_pixel_array,
+            self._ct_series,
+            self._ct_series_mask_array,
             SegmentationTypeValues.FRACTIONAL.value,
             self._segment_descriptions,
             self._series_instance_uid,
@@ -1425,6 +1427,27 @@ class TestSegmentation:
             transfer_syntax_uid=RLELossless,
             workers=2,
         )
+
+    def test_construction_workers_manual(self):
+        # Create a segmentation with multiple workers created manually
+        with ProcessPoolExecutor(2) as pool:
+            instance = Segmentation(
+            self._ct_series,
+            self._ct_series_mask_array,
+                SegmentationTypeValues.FRACTIONAL.value,
+                self._segment_descriptions,
+                self._series_instance_uid,
+                self._series_number,
+                self._sop_instance_uid,
+                self._instance_number,
+                self._manufacturer,
+                self._manufacturer_model_name,
+                self._software_versions,
+                self._device_serial_number,
+                content_label=self._content_label,
+                transfer_syntax_uid=RLELossless,
+                workers=pool,
+            )
 
     def test_pixel_types_fractional(
         self,

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -1407,6 +1407,25 @@ class TestSegmentation:
         assert SegmentsOverlapValues[instance.SegmentsOverlap] == \
             SegmentsOverlapValues.NO
 
+    def test_construction_workers(self):
+        instance = Segmentation(
+            [self._ct_image],
+            self._ct_pixel_array,
+            SegmentationTypeValues.FRACTIONAL.value,
+            self._segment_descriptions,
+            self._series_instance_uid,
+            self._series_number,
+            self._sop_instance_uid,
+            self._instance_number,
+            self._manufacturer,
+            self._manufacturer_model_name,
+            self._software_versions,
+            self._device_serial_number,
+            content_label=self._content_label,
+            transfer_syntax_uid=RLELossless,
+            workers=2,
+        )
+
     def test_pixel_types_fractional(
         self,
         fractional_transfer_syntax_uid,


### PR DESCRIPTION
Add the ability to use concurrency to encode frames when creating segmentations.

When using encapsulated transfer syntaxes, the process of encoding frames takes a significant amount of the total time for creation of a Segmentation object. For large multiframe segmentations such as those of WSIs, this can take several minutes. Parallelising the encoding of frames is an obvious place for significant performance gains.

In this PR, I add the ability to use multiprocessing for frame encoding using the Python standard library's `concurrent.futures` module. The user specifies a `workers` parameter governing the number of worker processes to spawn (with the default remaining no worker threads). Alternatively they may "bring their own" worker pool by providing an instance of any `concurrent.futures.Executor`. This has two potential benefits. First it allows a worker pool to be re-used in programs where a large number of segmentations needs to be created to save to overhead of setting up the worker pools. Secondly, it gives the user more control over the multiprocessing context if they want it. For example, in principle, they could pass a ThreadPoolExecutor to use multi-threading rather that multiprocessing.

I also made a few other tweaks to the segmentation array processing for further efficiency gains. Most notably, I adjusted the `_get_segment_pixel_array` method to return the array for a single frame and a single segment (as opposed to a all frames and a single segment). This makes the looping logic a bit simpler and it turns out that this is slightly faster, presumably because it avoid the need to allocate memory for large arrays. 
