### PR TITLE
Specimen description and preparation step fixes

### DIFF
--- a/src/highdicom/ann/content.py
+++ b/src/highdicom/ann/content.py
@@ -485,7 +485,7 @@ class AnnotationGroup(Dataset):
     @property
     def primary_anatomic_structures(self) -> List[CodedConcept]:
         """List[highdicom.sr.CodedConcept]:
-            List of anatomic anatomic structures the annotations represent.
+            List of anatomic structures the annotations represent.
             May be empty.
 
         """

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1447,7 +1447,8 @@ class SpecimenDescription(Dataset):
             Steps that were applied during the preparation of the examined
             specimen in the laboratory prior to image acquisition
         specimen_type: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
-            The type of the examined specimen.
+            The anatomic pathology specimen type of the specimen (see :dcm:`CID 8103 <part16/sect_CID_8103.html>`
+            "Anatomic Pathology Specimen Type" for options).
         specimen_short_description: str, optional
             Short description of the examined specimen.
         specimen_detailed_description: str, optional

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1170,7 +1170,7 @@ class SpecimenPreparationStep(Dataset):
         return items[0].value
 
     @property
-    def issuer_of_specimen_id(self) -> Union[IssuerOfIdentifier, None]:
+    def issuer_of_specimen_id(self) -> Union[str, None]:
         """highdicom.content.IssuerOfIdentifier: Issuer of specimen id"""
 
         items = self.SpecimenPreparationStepContentItemSequence.find(

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1183,6 +1183,8 @@ class SpecimenPreparationStep(Dataset):
 
     @property
     def specimen_container(self) -> Union[CodedConcept, None]:
+        """highdicom.sr.CodedConcept: Specimen container"""
+
         items = self.SpecimenPreparationStepContentItemSequence.find(
             codes.SCT.SpecimenContainer
         )
@@ -1192,6 +1194,8 @@ class SpecimenPreparationStep(Dataset):
 
     @property
     def specimen_type(self) -> Union[CodedConcept, None]:
+        """highdicom.sr.CodedConcept: Specimen type"""
+
         items = self.SpecimenPreparationStepContentItemSequence.find(
             codes.SCT.SpecimenType
         )

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1500,7 +1500,10 @@ class SpecimenDescription(Dataset):
             self.SpecimenLocalizationContentItemSequence = loc_seq
 
         if specimen_type is not None:
+            if isinstance(specimen_type, Code):
+                specimen_type = CodedConcept.from_code(specimen_type)
             self.SpecimenTypeCodeSequence = [specimen_type]
+
         if specimen_short_description is not None:
             _check_long_string(specimen_short_description)
             self.SpecimenShortDescription = specimen_short_description

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -960,7 +960,9 @@ class SpecimenPreparationStep(Dataset):
         processing_datetime: Optional[datetime.datetime] = None,
         issuer_of_specimen_id: Optional[IssuerOfIdentifier] = None,
         fixative: Optional[Union[Code, CodedConcept]] = None,
-        embedding_medium: Optional[Union[Code, CodedConcept]] = None
+        embedding_medium: Optional[Union[Code, CodedConcept]] = None,
+        specimen_container: Optional[Union[Code, CodedConcept]] = None,
+        specimen_type: Optional[Union[Code, CodedConcept]] = None,
     ):
         """
         Parameters
@@ -978,6 +980,10 @@ class SpecimenPreparationStep(Dataset):
             Fixative used during processing
         embedding_medium: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
             Embedding medium used during processing
+        specimen_container: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
+            Container the specimen resides in.
+        specimen_type: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
+            The anatomic pathology specimen type of the specimen.
 
         """  # noqa: E501
         super().__init__()
@@ -1067,6 +1073,20 @@ class SpecimenPreparationStep(Dataset):
             sequence.append(embedding_medium_item)
         self.SpecimenPreparationStepContentItemSequence = sequence
 
+        if specimen_container is not None:
+            specimen_container_item = CodeContentItem(
+                name=codes.SCT.SpecimenContainer,
+                value=specimen_container
+            )
+            sequence.append(specimen_container_item)
+
+        if specimen_type is not None:
+            specimen_type_item = CodeContentItem(
+                name=codes.SCT.SpecimenType,
+                value=specimen_type
+            )
+            sequence.append(specimen_type_item)
+
     @property
     def specimen_id(self) -> str:
         """str: Specimen identifier"""
@@ -1155,6 +1175,24 @@ class SpecimenPreparationStep(Dataset):
 
         items = self.SpecimenPreparationStepContentItemSequence.find(
             codes.DCM.IssuerOfSpecimenIdentifier
+        )
+        if len(items) == 0:
+            return None
+        return items[0].value
+
+    @property
+    def specimen_container(self) -> Union[CodedConcept, None]:
+        items = self.SpecimenPreparationStepContentItemSequence.find(
+            codes.SCT.SpecimenContainer
+        )
+        if len(items) == 0:
+            return None
+        return items[0].value
+
+    @property
+    def specimen_type(self) -> Union[CodedConcept, None]:
+        items = self.SpecimenPreparationStepContentItemSequence.find(
+            codes.SCT.SpecimenType
         )
         if len(items) == 0:
             return None

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1501,6 +1501,7 @@ class SpecimenDescription(Dataset):
         if specimen_type is not None:
             self.SpecimenTypeCodeSequence = [specimen_type]
         if specimen_short_description is not None:
+            _check_long_string(specimen_short_description)
             self.SpecimenShortDescription = specimen_short_description
         if specimen_detailed_description is not None:
             self.SpecimenDetailedDescription = specimen_detailed_description

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -978,15 +978,17 @@ class SpecimenPreparationStep(Dataset):
             Description of processing
         issuer_of_specimen_id: highdicom.IssuerOfIdentifier, optional
         fixative: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
-            Fixative used during processing
+            Fixative used during processing (see :dcm:`CID 8114 <part16/sect_CID_8114.html>`
+            "Specimen Fixative" for options).
         embedding_medium: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
-            Embedding medium used during processing
+            Embedding medium used during processing see :dcm:`CID 8115 <part16/sect_CID_8115.html>`
+            "Specimen Embedding Media" for options).
         specimen_container: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
-            Container the specimen resides in (see
-            :dcm:`CID 8101 <part16/sect_CID_8101.html>`
+            Container the specimen resides in (see :dcm:`CID 8101 <part16/sect_CID_8101.html>`
             "Container Type" for options).
         specimen_type: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
-            The anatomic pathology specimen type of the specimen.
+            The anatomic pathology specimen type of the specimen (see :dcm:`CID 8103 <part16/sect_CID_8103.html>`
+            "Anatomic Pathology Specimen Type" for options).
 
         """  # noqa: E501
         super().__init__()
@@ -1087,8 +1089,6 @@ class SpecimenPreparationStep(Dataset):
             )
             sequence.append(specimen_type_item)
         self.SpecimenPreparationStepContentItemSequence = sequence
-
-
 
     @property
     def specimen_id(self) -> str:

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1470,16 +1470,17 @@ class SpecimenDescription(Dataset):
 
     @property
     def specimen_id(self) -> str:
-        """str: Specimen identifier"""
+        """str: Specimen identifier."""
         return str(self.SpecimenIdentifier)
 
     @property
     def specimen_uid(self) -> UID:
-        """highdicom.UID: Unique specimen identifier"""
+        """highdicom.UID: Unique specimen identifier."""
         return UID(self.SpecimenUID)
 
     @property
     def specimen_location(self) -> Union[str, Tuple[float, float, float], None]:
+        """Tuple[float, float, float]: Specimen location in container."""
         sequence = self.get("SpecimenLocalizationContentItemSequence")
         if sequence is None:
             return None
@@ -1489,11 +1490,12 @@ class SpecimenDescription(Dataset):
 
     @property
     def specimen_preparation_steps(self) -> List[SpecimenPreparationStep]:
-        """highdicom.SpecimenPreparationStep: Specimen preparation steps"""
+        """highdicom.SpecimenPreparationStep: Specimen preparation steps."""
         return list(self.SpecimenPreparationSequence)
 
     @property
     def specimen_type(self) -> Union[CodedConcept, None]:
+        """highdicom.sr.CodedConcept: Specimen type."""
         sequence = self.get("SpecimenTypeCodeSequence")
         if sequence is None:
             return None
@@ -1501,14 +1503,17 @@ class SpecimenDescription(Dataset):
 
     @property
     def specimen_short_description(self) -> Union[str, None]:
+        """str: Short description of specimen."""
         return self.get("SpecimenShortDescription")
 
     @property
     def specimen_detailed_description(self) -> Union[str, None]:
+        """str: Detailed description of specimen."""
         return self.get("SpecimenDetailedDescription")
 
     @property
     def issuer_of_specimen_id(self) -> Union[IssuerOfIdentifier, None]:
+        """IssuerOfIdentifier: Issuer of identifier for the specimen."""
         sequence = self.get("IssuerOfTheSpecimenIdentifierSequence")
         if len(sequence) == 0:
             return None
@@ -1516,6 +1521,8 @@ class SpecimenDescription(Dataset):
 
     @property
     def primary_anatomic_structures(self) -> Union[List[CodedConcept], None]:
+        """List[highdicom.sr.CodedConcept]: List of anatomic structures of the
+         specimen."""
         return self.get("PrimaryAnatomicStructureSequence")
 
     @classmethod

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1072,21 +1072,21 @@ class SpecimenPreparationStep(Dataset):
                 value=embedding_medium
             )
             sequence.append(embedding_medium_item)
-        self.SpecimenPreparationStepContentItemSequence = sequence
-
         if specimen_container is not None:
             specimen_container_item = CodeContentItem(
                 name=codes.SCT.SpecimenContainer,
                 value=specimen_container
             )
             sequence.append(specimen_container_item)
-
         if specimen_type is not None:
             specimen_type_item = CodeContentItem(
                 name=codes.SCT.SpecimenType,
                 value=specimen_type
             )
             sequence.append(specimen_type_item)
+        self.SpecimenPreparationStepContentItemSequence = sequence
+
+
 
     @property
     def specimen_id(self) -> str:

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1556,7 +1556,10 @@ class SpecimenDescription(Dataset):
                 for ds in desc.SpecimenTypeCodeSequence
             ]
         if hasattr(desc, 'SpecimenLocalizationContentItemSequence'):
-            if desc.SpecimenLocalizationContentItemSequence[0].ValueType == ValueTypeValues.TEXT.value:
+            if (
+                desc.SpecimenLocalizationContentItemSequence[0].ValueType ==
+                ValueTypeValues.TEXT.value
+            ):
                 content_item_type = TextContentItem
             else:
                 content_item_type = NumContentItem
@@ -1564,7 +1567,6 @@ class SpecimenDescription(Dataset):
                 content_item_type.from_dataset(ds)
                 for ds in desc.SpecimenLocalizationContentItemSequence
             ]
-
 
         return desc
 

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1126,6 +1126,40 @@ class SpecimenPreparationStep(Dataset):
             return None
         return items[0].value
 
+    @property
+    def processing_description(self) -> Union[str, CodedConcept, None]:
+        """Union[str, highdicom.sr.CodedConcept]: Processing description"""
+        if isinstance(self._processing_procedure, SpecimenProcessing):
+            return None
+        items = self.SpecimenPreparationStepContentItemSequence.find(
+            codes.DCM.ProcessingStepDescription
+        )
+        if len(items) == 0:
+            return None
+        return items[0].value
+
+    @property
+    def processing_datetime(self) -> Union[datetime.datetime, None]:
+        """datetime.datetime: Processing datetime"""
+
+        items = self.SpecimenPreparationStepContentItemSequence.find(
+            codes.DCM.DatetimeOfProcessing
+        )
+        if len(items) == 0:
+            return None
+        return items[0].value
+
+    @property
+    def issuer_of_specimen_id(self) -> Union[IssuerOfIdentifier, None]:
+        """highdicom.content.IssuerOfIdentifier: Issuer of specimen id"""
+
+        items = self.SpecimenPreparationStepContentItemSequence.find(
+            codes.DCM.IssuerOfSpecimenIdentifier
+        )
+        if len(items) == 0:
+            return None
+        return items[0].value
+
     @classmethod
     def from_dataset(
         cls,

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -981,6 +981,14 @@ class SpecimenPreparationStep(Dataset):
 
         """  # noqa: E501
         super().__init__()
+        if (
+            isinstance(processing_procedure, SpecimenProcessing) and
+            processing_description is not None
+        ):
+            raise ValueError(
+                'Processing description must be None if procedure is of type '
+                '"SpecimenProcessing".'
+            )
         sequence = ContentSequence(is_root=False, is_sr=False)
         specimen_identifier_item = TextContentItem(
             name=codes.DCM.SpecimenIdentifier,
@@ -1184,7 +1192,7 @@ class SpecimenPreparationStep(Dataset):
                 raise ValueError(
                     'Specimen Preparation Step Content Item Sequence must '
                     'contain exactly one content item "Processing Step '
-                    'Description" when processing type is "Specimen .'
+                    'Description" when processing type is "Specimen '
                     'Processing".'
                 )
             instance._processing_procedure = SpecimenProcessing(

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1030,7 +1030,7 @@ class SpecimenPreparationStep(Dataset):
 
         if processing_datetime is not None:
             processing_datetime_item = DateTimeContentItem(
-                name=codes.DCM.DateTimeOfProcessing,
+                name=codes.DCM.DatetimeOfProcessing,
                 value=processing_datetime
             )
             sequence.append(processing_datetime_item)

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -740,6 +740,7 @@ class IssuerOfIdentifier(Dataset):
     def from_dataset(
         cls,
         dataset: Dataset,
+        copy: bool = True,
     ) -> 'IssuerOfIdentifier':
         """Construct object from an existing dataset.
 
@@ -747,6 +748,10 @@ class IssuerOfIdentifier(Dataset):
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -754,7 +759,10 @@ class IssuerOfIdentifier(Dataset):
             Issuer of identifier
 
         """
-        issuer_of_identifier = deepcopy(dataset)
+        if copy:
+            issuer_of_identifier = deepcopy(dataset)
+        else:
+            issuer_of_identifier = dataset
         issuer_of_identifier.__class__ = cls
         if hasattr(issuer_of_identifier, "LocalNamespaceEntityID"):
             issuer_id = issuer_of_identifier.LocalNamespaceEntityID

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1353,13 +1353,13 @@ class SpecimenDescription(Dataset):
         specimen_preparation_steps: Optional[
             Sequence[SpecimenPreparationStep]
         ] = None,
-        specimen_type: Optional[Union[Code, CodedConcept]] = None,
-        specimen_short_description: Optional[str] = None,
-        specimen_detailed_description: Optional[str] = None,
         issuer_of_specimen_id: Optional[IssuerOfIdentifier] = None,
         primary_anatomic_structures: Optional[
             Sequence[Union[Code, CodedConcept]]
-        ] = None
+        ] = None,
+        specimen_type: Optional[Union[Code, CodedConcept]] = None,
+        specimen_short_description: Optional[str] = None,
+        specimen_detailed_description: Optional[str] = None,
     ):
         """
         Parameters

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1035,6 +1035,7 @@ class SpecimenPreparationStep(Dataset):
         processing_description: Union[str, pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
             Description of processing
         issuer_of_specimen_id: highdicom.IssuerOfIdentifier, optional
+            The issuer of the identifier of the processed specimen.
         fixative: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
             Fixative used during processing (see :dcm:`CID 8114 <part16/sect_CID_8114.html>`
             "Specimen Fixative" for options).

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -878,13 +878,15 @@ class TimeContentItem(ContentItem):
     def value(self) -> datetime.time:
         """datetime.time: time"""
         if isinstance(self.Time, TM):
-            return self.Time
-        try:
-            return TM(self.Time)
-        except ValueError as exception:
-            raise ValueError(
-                f'Could not decode time value "{self.Time}"'
-            ) from exception
+            value = self.Time
+        else:
+            try:
+                value = TM(self.Time)
+            except ValueError as exception:
+                raise ValueError(
+                    f'Could not decode time value "{self.Time}"'
+                ) from exception
+        return value.replace()
 
 
     @classmethod
@@ -949,13 +951,15 @@ class DateContentItem(ContentItem):
     def value(self) -> datetime.date:
         """datetime.date: date"""
         if isinstance(self.Date, DA):
-            return self.Date
-        try:
-            return DA(self.Date)
-        except ValueError as exception:
-            raise ValueError(
-                f'Could not decode date value "{self.Date}"'
-            ) from exception
+            value = self.Date
+        else:
+            try:
+                value = DA(self.Date)
+            except ValueError as exception:
+                raise ValueError(
+                    f'Could not decode date value "{self.Date}"'
+                ) from exception
+        return value.replace()
 
     @classmethod
     def from_dataset(
@@ -1019,13 +1023,15 @@ class DateTimeContentItem(ContentItem):
     def value(self) -> datetime.datetime:
         """datetime.datetime: datetime"""
         if isinstance(self.DateTime, DT):
-            return self.DateTime
-        try:
-            return DT(self.DateTime)
-        except ValueError as exception:
-            raise ValueError(
-                f'Could not decode datetime value "{self.DateTime}"'
-            ) from exception
+            value = self.DateTime
+        else:
+            try:
+                value = DT(self.DateTime)
+            except ValueError as exception:
+                raise ValueError(
+                    f'Could not decode datetime value "{self.DateTime}"'
+                ) from exception
+        return value.replace()
 
     @classmethod
     def from_dataset(

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -888,7 +888,6 @@ class TimeContentItem(ContentItem):
                 ) from exception
         return value.replace()
 
-
     @classmethod
     def from_dataset(
         cls,

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -877,19 +877,15 @@ class TimeContentItem(ContentItem):
     @property
     def value(self) -> datetime.time:
         """datetime.time: time"""
-        allowed_formats = [
-            '%H:%M:%S.%f',
-            '%H:%M:%S',
-            '%H:%M',
-            '%H',
-        ]
-        for fmt in allowed_formats:
-            try:
-                dt = datetime.datetime.strptime(self.Time.isoformat(), fmt)
-                return dt.time()
-            except ValueError:
-                continue
-        raise ValueError(f'Could not decode time value "{self.Time}"')
+        if isinstance(self.Time, TM):
+            return self.Time
+        try:
+            return TM(self.Time)
+        except ValueError as exception:
+            raise ValueError(
+                f'Could not decode time value "{self.Time}"'
+            ) from exception
+
 
     @classmethod
     def from_dataset(
@@ -952,8 +948,14 @@ class DateContentItem(ContentItem):
     @property
     def value(self) -> datetime.date:
         """datetime.date: date"""
-        fmt = '%Y-%m-%d'
-        return datetime.datetime.strptime(self.Date.isoformat(), fmt).date()
+        if isinstance(self.Date, DA):
+            return self.Date
+        try:
+            return DA(self.Date)
+        except ValueError as exception:
+            raise ValueError(
+                f'Could not decode date value "{self.Date}"'
+            ) from exception
 
     @classmethod
     def from_dataset(
@@ -1016,26 +1018,14 @@ class DateTimeContentItem(ContentItem):
     @property
     def value(self) -> datetime.datetime:
         """datetime.datetime: datetime"""
-        allowed_formats = [
-            '%Y-%m-%dT%H:%M:%S.%f%z',
-            '%Y-%m-%dT%H:%M:%S.%f',
-            '%Y-%m-%dT%H:%M:%S',
-            '%Y-%m-%dT%H:%M:%S%z',
-            '%Y-%m-%dT%H:%M',
-            '%Y-%m-%dT%H:%M%z',
-            '%Y-%m-%dT%H',
-            '%Y-%m-%dT%H%z',
-            '%Y-%m-%d',
-            '%Y-%m',
-            '%Y',
-        ]
-        for fmt in allowed_formats:
-            try:
-                dt = datetime.datetime.strptime(self.DateTime.isoformat(), fmt)
-                return dt
-            except ValueError:
-                continue
-        raise ValueError(f'Could not decode datetime value "{self.DateTime}"')
+        if isinstance(self.DateTime, DT):
+            return self.DateTime
+        try:
+            return DT(self.DateTime)
+        except ValueError as exception:
+            raise ValueError(
+                f'Could not decode datetime value "{self.DateTime}"'
+            ) from exception
 
     @classmethod
     def from_dataset(

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -5,6 +5,7 @@ import pytest
 from pydicom import dcmread
 from pydicom.dataset import Dataset
 from pydicom.sr.codedict import codes
+from pydicom.sr.coding import Code
 from pydicom.data import get_testdata_file, get_testdata_files
 
 import numpy as np
@@ -1403,6 +1404,23 @@ class TestSpecimenDescription(TestCase):
                 specimen_uid=specimen_uid,
                 specimen_short_description=specimen_short_description
             )
+
+    def test_construction_with_code_specimen_type(self):
+        specimen_id = 'specimen 1'
+        specimen_uid = UID()
+        specimen_type = Code(
+            "specimen type",
+            "test",
+            "test specimen type"
+        )
+        instance = SpecimenDescription(
+            specimen_id=specimen_id,
+            specimen_uid=specimen_uid,
+            specimen_type=specimen_type,
+        )
+        assert isinstance(instance.specimen_type, CodedConcept)
+        assert instance.specimen_type == specimen_type
+
 
     def test_construction_with_preparation_steps(self):
         parent_specimen_id = 'surgical specimen'

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1038,6 +1038,7 @@ class TestPaletteColorLUTTransformation(TestCase):
                 blue_lut=b_lut,
             )
 
+class TestSpecimenPreparationStep:
     def test_construction_staining_from_dataset(self):
         specimen_id = 'specimen id'
         processing_type = codes.SCT.Staining
@@ -1113,6 +1114,8 @@ class TestPaletteColorLUTTransformation(TestCase):
         issuer_of_specimen_id = IssuerOfIdentifier("issuer id")
         fixative = CodedConcept("fixative", "test", "test fixative")
         embedding_medium = CodedConcept("embedding", "test", "test embedding")
+        specimen_container = CodedConcept("specimen container", "test", "test specimen container")
+        specimen_type = CodedConcept("specimen type", "test", "test specimen type")
 
         instance = SpecimenPreparationStep(
             specimen_id=specimen_id,
@@ -1121,11 +1124,13 @@ class TestPaletteColorLUTTransformation(TestCase):
             processing_datetime=processing_datetime,
             issuer_of_specimen_id=issuer_of_specimen_id,
             fixative=fixative,
-            embedding_medium=embedding_medium
+            embedding_medium=embedding_medium,
+            specimen_container=specimen_container,
+            specimen_type=specimen_type
         )
 
         seq = instance.SpecimenPreparationStepContentItemSequence
-        assert len(seq) == 8
+        assert len(seq) == 10
 
         specimen_id_item = seq[0]
         assert specimen_id_item.name == codes.DCM.SpecimenIdentifier
@@ -1167,6 +1172,16 @@ class TestPaletteColorLUTTransformation(TestCase):
         assert embedding_item.value == embedding_medium
         assert embedding_item.relationship_type is None
 
+        specimen_container_item = seq[8]
+        assert specimen_container_item.name == codes.SCT.SpecimenContainer
+        assert specimen_container_item.value == specimen_container
+        assert specimen_container_item.relationship_type is None
+
+        specimen_type_item = seq[9]
+        assert specimen_type_item.name == codes.SCT.SpecimenType
+        assert specimen_type_item.value == specimen_type
+        assert specimen_type_item.relationship_type is None
+
     def test_construction_processing_from_dataset(self):
         specimen_id = 'specimen id'
         processing_type = codes.SCT.SpecimenProcessing
@@ -1207,6 +1222,8 @@ class TestPaletteColorLUTTransformation(TestCase):
         issuer_of_specimen_id = IssuerOfIdentifier("issuer id")
         fixative = CodedConcept("fixative", "test", "test fixative")
         embedding_medium = CodedConcept("embedding", "test", "test embedding")
+        specimen_container = CodedConcept("specimen container", "test", "test specimen container")
+        specimen_type = CodedConcept("specimen type", "test", "test specimen type")
         dataset = Dataset()
         dataset.SpecimenPreparationStepContentItemSequence = [
             TextContentItem(
@@ -1240,8 +1257,15 @@ class TestPaletteColorLUTTransformation(TestCase):
             CodeContentItem(
                 name=codes.SCT.TissueEmbeddingMedium,
                 value=embedding_medium
+            ),
+            CodeContentItem(
+                name=codes.SCT.SpecimenContainer,
+                value=specimen_container
+            ),
+            CodeContentItem(
+                name=codes.SCT.SpecimenType,
+                value=specimen_type
             )
-
         ]
         dataset_reread = write_and_read_dataset(dataset)
         instance = SpecimenPreparationStep.from_dataset(dataset_reread)
@@ -1256,6 +1280,8 @@ class TestPaletteColorLUTTransformation(TestCase):
         assert processing_procedure.procedure == procedure
         assert instance.processing_datetime == processing_datetime
         assert instance.issuer_of_specimen_id == issuer_of_specimen_id.LocalNamespaceEntityID
+        assert instance.specimen_container == specimen_container
+        assert instance.specimen_type == specimen_type
 
 class TestSpecimenDescription(TestCase):
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1382,6 +1382,28 @@ class TestSpecimenDescription(TestCase):
             instance.primary_anatomic_structures == primary_anatomic_structures
         )
 
+    def test_construction_with_to_long_short_description(self):
+        specimen_id = 'specimen 1'
+        specimen_uid = UID()
+        specimen_short_description = "x" * 65
+        with pytest.raises(ValueError):
+            SpecimenDescription(
+                specimen_id=specimen_id,
+                specimen_uid=specimen_uid,
+                specimen_short_description=specimen_short_description
+            )
+
+    def test_construction_with_backslash_in_short_description(self):
+        specimen_id = 'specimen 1'
+        specimen_uid = UID()
+        specimen_short_description = 'short_description_with_backslash\\'
+        with pytest.raises(ValueError):
+            SpecimenDescription(
+                specimen_id=specimen_id,
+                specimen_uid=specimen_uid,
+                specimen_short_description=specimen_short_description
+            )
+
     def test_construction_with_preparation_steps(self):
         parent_specimen_id = 'surgical specimen'
         specimen_id = 'section specimen'

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1421,7 +1421,6 @@ class TestSpecimenDescription(TestCase):
         assert isinstance(instance.specimen_type, CodedConcept)
         assert instance.specimen_type == specimen_type
 
-
     def test_construction_with_preparation_steps(self):
         parent_specimen_id = 'surgical specimen'
         specimen_id = 'section specimen'

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -904,6 +904,7 @@ class TestSpecimenPreparationStep(TestCase):
         assert isinstance(processing_procedure, SpecimenCollection)
         assert processing_procedure.procedure == procedure
         assert instance.processing_datetime == processing_datetime
+        assert isinstance(instance.issuer_of_specimen_id, str)
         assert (
             instance.issuer_of_specimen_id ==
             issuer_of_specimen_id.LocalNamespaceEntityID

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -8,6 +8,7 @@ from pydicom.sr.codedict import codes
 from pydicom.data import get_testdata_file, get_testdata_files
 
 import numpy as np
+from highdicom.enum import UniversalEntityIDTypeValues
 
 from highdicom.sr import CodedConcept
 from highdicom import (
@@ -1483,7 +1484,48 @@ class TestSpecimenDescription(TestCase):
             instance.specimen_detailed_description ==
             specimen_detailed_description
         )
+        assert isinstance(instance.issuer_of_specimen_id, IssuerOfIdentifier)
         assert instance.issuer_of_specimen_id == issuer_of_specimen_id
         assert (
             instance.primary_anatomic_structures == primary_anatomic_structures
         )
+
+
+class TestIssuerOfIdentifier(TestCase):
+    def test_construction(self):
+        issuer_of_identifier = "issuer of identifier"
+        instance = IssuerOfIdentifier(issuer_of_identifier)
+        assert instance.issuer_of_identifier == issuer_of_identifier
+        assert instance.issuer_of_identifier_type is None
+
+    def test_construction_with_optionals(self):
+        issuer_of_identifier = "issuer of identifier id"
+        issuer_of_identifier_type = UniversalEntityIDTypeValues.DNS
+        instance = IssuerOfIdentifier(
+            issuer_of_identifier,
+            issuer_of_identifier_type
+        )
+        assert instance.issuer_of_identifier == issuer_of_identifier
+        assert instance.issuer_of_identifier_type == issuer_of_identifier_type
+
+    def test_construction_from_dataset(self):
+        issuer_of_identifier = "issuer of identifier"
+        dataset = Dataset()
+        dataset.LocalNamespaceEntityID = issuer_of_identifier
+        dataset_reread = write_and_read_dataset(dataset)
+        instance = IssuerOfIdentifier.from_dataset(dataset_reread)
+        assert isinstance(instance, IssuerOfIdentifier)
+        assert instance.issuer_of_identifier == issuer_of_identifier
+        assert instance.issuer_of_identifier_type is None
+
+    def test_construction_from_dataset_with_optionals(self):
+        issuer_of_identifier = "issuer of identifier"
+        issuer_of_identifier_type = UniversalEntityIDTypeValues.DNS
+        dataset = Dataset()
+        dataset.UniversalEntityID = issuer_of_identifier
+        dataset.UniversalEntityIDType = issuer_of_identifier_type.value
+        dataset_reread = write_and_read_dataset(dataset)
+        instance = IssuerOfIdentifier.from_dataset(dataset_reread)
+        assert isinstance(instance, IssuerOfIdentifier)
+        assert instance.issuer_of_identifier == issuer_of_identifier
+        assert instance.issuer_of_identifier_type == issuer_of_identifier_type

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1294,7 +1294,45 @@ class TestSpecimenDescription(TestCase):
         )
         assert instance.specimen_id == specimen_id
         assert instance.specimen_uid == specimen_uid
+        assert instance.specimen_location is None
         assert len(instance.specimen_preparation_steps) == 0
+        assert instance.specimen_type is None
+        assert instance.specimen_short_description is None
+        assert instance.specimen_detailed_description is None
+        assert instance.issuer_of_specimen_id is None
+        assert instance.primary_anatomic_structures is None
+
+    def test_construction_optionals(self):
+        specimen_id = 'specimen 1'
+        specimen_uid = UID()
+        specimen_location = "specimen location"
+        specimen_type = CodedConcept("specimen type", "test", "test specimen type")
+        specimen_short_description = "specimen short description"
+        specimen_detailed_description = "specimen detailed description"
+        issuer_of_specimen_id = IssuerOfIdentifier("issuer id")
+        primary_anatomic_structures = [
+            CodedConcept(
+                "anatomic strucutre",
+                "test",
+                "test anatomic structure"
+            )
+        ]
+        instance = SpecimenDescription(
+            specimen_id=specimen_id,
+            specimen_uid=specimen_uid,
+            specimen_location=specimen_location,
+            specimen_type=specimen_type,
+            specimen_short_description=specimen_short_description,
+            specimen_detailed_description=specimen_detailed_description,
+            issuer_of_specimen_id=issuer_of_specimen_id,
+            primary_anatomic_structures=primary_anatomic_structures
+        )
+        assert instance.specimen_location == specimen_location
+        assert instance.specimen_type == specimen_type
+        assert instance.specimen_short_description == specimen_short_description
+        assert instance.specimen_detailed_description == specimen_detailed_description
+        assert instance.issuer_of_specimen_id == issuer_of_specimen_id
+        assert instance.primary_anatomic_structures == primary_anatomic_structures
 
     def test_construction_with_preparation_steps(self):
         parent_specimen_id = 'surgical specimen'
@@ -1347,3 +1385,50 @@ class TestSpecimenDescription(TestCase):
         assert instance.specimen_id == specimen_id
         assert instance.specimen_uid == specimen_uid
         assert len(instance.specimen_preparation_steps) == 0
+
+    def test_construction_from_dataset_with_optionals(self):
+        specimen_id = 'specimen 1'
+        specimen_uid = UID()
+        specimen_location = "specimen location"
+        specimen_preparation_steps = [
+            SpecimenPreparationStep(
+                specimen_id,
+                SpecimenCollection(procedure=codes.SCT.Biopsy)
+            )
+        ]
+        specimen_type = CodedConcept("specimen type", "test", "test specimen type")
+        specimen_short_description = "specimen short description"
+        specimen_detailed_description = "specimen detailed description"
+        issuer_of_specimen_id = IssuerOfIdentifier("issuer id")
+        primary_anatomic_structures = [
+            CodedConcept(
+                "anatomic strucutre",
+                "test",
+                "test anatomic structure"
+            )
+        ]
+        dataset = Dataset()
+        dataset.SpecimenIdentifier = specimen_id
+        dataset.SpecimenUID = str(specimen_uid)
+        dataset.SpecimenLocalizationContentItemSequence = [
+            TextContentItem(
+                name=codes.DCM.LocationOfSpecimen,
+                value=specimen_location
+            )
+        ]
+        dataset.SpecimenTypeCodeSequence = [specimen_type]
+        dataset.SpecimenPreparationSequence = specimen_preparation_steps
+        dataset.SpecimenShortDescription = specimen_short_description
+        dataset.SpecimenDetailedDescription = specimen_detailed_description
+        dataset.IssuerOfTheSpecimenIdentifierSequence = [issuer_of_specimen_id]
+        dataset.PrimaryAnatomicStructureSequence = primary_anatomic_structures
+        dataset_reread = write_and_read_dataset(dataset)
+        instance = SpecimenDescription.from_dataset(dataset_reread)
+        assert instance.specimen_location == specimen_location
+        assert instance.specimen_preparation_steps == specimen_preparation_steps
+        assert instance.specimen_type == specimen_type
+        assert instance.specimen_short_description == specimen_short_description
+        assert instance.specimen_detailed_description == specimen_detailed_description
+        assert instance.issuer_of_specimen_id == issuer_of_specimen_id
+        assert instance.primary_anatomic_structures == primary_anatomic_structures
+

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -691,7 +691,10 @@ class TestSpecimenPreparationStep(TestCase):
         assert processing_type_item.relationship_type is None
 
         processing_step_description_item = seq[2]
-        assert processing_step_description_item.name == codes.DCM.ProcessingStepDescription
+        assert (
+            processing_step_description_item.name ==
+            codes.DCM.ProcessingStepDescription
+        )
         assert processing_step_description_item.value == description
         assert processing_step_description_item.relationship_type is None
 
@@ -705,8 +708,16 @@ class TestSpecimenPreparationStep(TestCase):
         issuer_of_specimen_id = IssuerOfIdentifier("issuer id")
         fixative = CodedConcept("fixative", "test", "test fixative")
         embedding_medium = CodedConcept("embedding", "test", "test embedding")
-        specimen_container = CodedConcept("specimen container", "test", "test specimen container")
-        specimen_type = CodedConcept("specimen type", "test", "test specimen type")
+        specimen_container = CodedConcept(
+            "specimen container",
+            "test",
+            "test specimen container"
+        )
+        specimen_type = CodedConcept(
+            "specimen type",
+            "test",
+            "test specimen type"
+        )
 
         instance = SpecimenPreparationStep(
             specimen_id=specimen_id,
@@ -729,27 +740,42 @@ class TestSpecimenPreparationStep(TestCase):
         assert specimen_id_item.relationship_type is None
 
         issuer_of_specimen_id_item = seq[1]
-        assert issuer_of_specimen_id_item.name == codes.DCM.IssuerOfSpecimenIdentifier
-        assert issuer_of_specimen_id_item.value == issuer_of_specimen_id.LocalNamespaceEntityID
+        assert (
+            issuer_of_specimen_id_item.name ==
+            codes.DCM.IssuerOfSpecimenIdentifier
+        )
+        assert (
+            issuer_of_specimen_id_item.value ==
+            issuer_of_specimen_id.LocalNamespaceEntityID
+        )
         assert issuer_of_specimen_id_item.relationship_type is None
 
         processing_type_item = seq[2]
-        assert processing_type_item.name == codes.DCM.ProcessingType
+        assert (
+            processing_type_item.name == codes.DCM.ProcessingType
+        )
         assert processing_type_item.value == processing_type
         assert processing_type_item.relationship_type is None
 
         processing_datetime_item = seq[3]
-        assert processing_datetime_item.name == codes.DCM.DatetimeOfProcessing
+        assert (
+            processing_datetime_item.name == codes.DCM.DatetimeOfProcessing
+        )
         assert processing_datetime_item.value == processing_datetime
         assert processing_datetime_item.relationship_type is None
 
         processing_description_item = seq[4]
-        assert processing_description_item.name == codes.DCM.ProcessingStepDescription
+        assert (
+            processing_description_item.name ==
+            codes.DCM.ProcessingStepDescription
+        )
         assert processing_description_item.value == processing_description
         assert processing_description_item.relationship_type is None
 
         collection_step_item = seq[5]
-        assert collection_step_item.name == codes.SCT.SpecimenCollection
+        assert (
+            collection_step_item.name == codes.SCT.SpecimenCollection
+        )
         assert collection_step_item.value == procedure
         assert collection_step_item.relationship_type is None
 
@@ -813,8 +839,16 @@ class TestSpecimenPreparationStep(TestCase):
         issuer_of_specimen_id = IssuerOfIdentifier("issuer id")
         fixative = CodedConcept("fixative", "test", "test fixative")
         embedding_medium = CodedConcept("embedding", "test", "test embedding")
-        specimen_container = CodedConcept("specimen container", "test", "test specimen container")
-        specimen_type = CodedConcept("specimen type", "test", "test specimen type")
+        specimen_container = CodedConcept(
+            "specimen container",
+            "test",
+            "test specimen container"
+        )
+        specimen_type = CodedConcept(
+            "specimen type",
+            "test",
+            "test specimen type"
+        )
         dataset = Dataset()
         dataset.SpecimenPreparationStepContentItemSequence = [
             TextContentItem(
@@ -870,7 +904,10 @@ class TestSpecimenPreparationStep(TestCase):
         assert isinstance(processing_procedure, SpecimenCollection)
         assert processing_procedure.procedure == procedure
         assert instance.processing_datetime == processing_datetime
-        assert instance.issuer_of_specimen_id == issuer_of_specimen_id.LocalNamespaceEntityID
+        assert (
+            instance.issuer_of_specimen_id ==
+            issuer_of_specimen_id.LocalNamespaceEntityID
+        )
         assert instance.specimen_container == specimen_container
         assert instance.specimen_type == specimen_type
 
@@ -1281,8 +1318,8 @@ class TestPaletteColorLUTTransformation(TestCase):
                 blue_lut=b_lut,
             )
 
-class TestSpecimenDescription(TestCase):
 
+class TestSpecimenDescription(TestCase):
     def test_construction(self):
         specimen_id = 'specimen 1'
         specimen_uid = UID()
@@ -1304,7 +1341,11 @@ class TestSpecimenDescription(TestCase):
         specimen_id = 'specimen 1'
         specimen_uid = UID()
         specimen_location = "specimen location"
-        specimen_type = CodedConcept("specimen type", "test", "test specimen type")
+        specimen_type = CodedConcept(
+            "specimen type",
+            "test",
+            "test specimen type"
+        )
         specimen_short_description = "specimen short description"
         specimen_detailed_description = "specimen detailed description"
         issuer_of_specimen_id = IssuerOfIdentifier("issuer id")
@@ -1328,9 +1369,16 @@ class TestSpecimenDescription(TestCase):
         assert instance.specimen_location == specimen_location
         assert instance.specimen_type == specimen_type
         assert instance.specimen_short_description == specimen_short_description
-        assert instance.specimen_detailed_description == specimen_detailed_description
-        assert instance.issuer_of_specimen_id == issuer_of_specimen_id
-        assert instance.primary_anatomic_structures == primary_anatomic_structures
+        assert (
+            instance.specimen_detailed_description ==
+            specimen_detailed_description
+        )
+        assert (
+            instance.issuer_of_specimen_id == issuer_of_specimen_id
+        )
+        assert (
+            instance.primary_anatomic_structures == primary_anatomic_structures
+        )
 
     def test_construction_with_preparation_steps(self):
         parent_specimen_id = 'surgical specimen'
@@ -1394,7 +1442,11 @@ class TestSpecimenDescription(TestCase):
                 SpecimenCollection(procedure=codes.SCT.Biopsy)
             )
         ]
-        specimen_type = CodedConcept("specimen type", "test", "test specimen type")
+        specimen_type = CodedConcept(
+            "specimen type",
+            "test",
+            "test specimen type"
+        )
         specimen_short_description = "specimen short description"
         specimen_detailed_description = "specimen detailed description"
         issuer_of_specimen_id = IssuerOfIdentifier("issuer id")
@@ -1426,7 +1478,11 @@ class TestSpecimenDescription(TestCase):
         assert instance.specimen_preparation_steps == specimen_preparation_steps
         assert instance.specimen_type == specimen_type
         assert instance.specimen_short_description == specimen_short_description
-        assert instance.specimen_detailed_description == specimen_detailed_description
+        assert (
+            instance.specimen_detailed_description ==
+            specimen_detailed_description
+        )
         assert instance.issuer_of_specimen_id == issuer_of_specimen_id
-        assert instance.primary_anatomic_structures == primary_anatomic_structures
-
+        assert (
+            instance.primary_anatomic_structures == primary_anatomic_structures
+        )

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1360,11 +1360,11 @@ class TestSpecimenDescription(TestCase):
             specimen_id=specimen_id,
             specimen_uid=specimen_uid,
             specimen_location=specimen_location,
+            issuer_of_specimen_id=issuer_of_specimen_id,
+            primary_anatomic_structures=primary_anatomic_structures,
             specimen_type=specimen_type,
             specimen_short_description=specimen_short_description,
             specimen_detailed_description=specimen_detailed_description,
-            issuer_of_specimen_id=issuer_of_specimen_id,
-            primary_anatomic_structures=primary_anatomic_structures
         )
         assert instance.specimen_location == specimen_location
         assert instance.specimen_type == specimen_type

--- a/tests/test_valuetypes.py
+++ b/tests/test_valuetypes.py
@@ -8,7 +8,11 @@ from pydicom.valuerep import DT, DA, TM
 
 from highdicom.sr.coding import CodedConcept
 from highdicom.sr.enum import ValueTypeValues
-from highdicom.sr.value_types import DateContentItem, DateTimeContentItem, TimeContentItem
+from highdicom.sr.value_types import (
+    DateContentItem,
+    DateTimeContentItem,
+    TimeContentItem
+)
 from tests.utils import write_and_read_dataset
 
 
@@ -38,7 +42,6 @@ class TestDateTimeContentItem:
         assert item.value_type == value_type
         assert isinstance(item.value, datetime.datetime)
         assert item.value.isoformat() == datetime_value.isoformat()
-
 
     @pytest.mark.parametrize("datetime_value", test_datetime_values)
     def test_from_dataset(self, datetime_value: DT):
@@ -77,7 +80,6 @@ class TestDateContentItem:
         assert isinstance(item.value, datetime.date)
         assert item.value.isoformat() == date_value.isoformat()
 
-
     def test_from_dataset(self):
         date_value = DA("20230623")
         name = codes.DCM.AcquisitionDate
@@ -96,6 +98,7 @@ class TestDateContentItem:
         assert item.value_type == value_type
         assert isinstance(item.value, datetime.date)
         assert item.value.isoformat() == date_value.isoformat()
+
 
 class TestTimeContentItem:
     test_time_values = [
@@ -120,7 +123,6 @@ class TestTimeContentItem:
         assert item.value_type == value_type
         assert isinstance(item.value, datetime.time)
         assert item.value.isoformat() == time_value.isoformat()
-
 
     @pytest.mark.parametrize("time_value", test_time_values)
     def test_from_dataset(self, time_value: TM):

--- a/tests/test_valuetypes.py
+++ b/tests/test_valuetypes.py
@@ -1,0 +1,142 @@
+import datetime
+
+import pytest
+from pydicom import Dataset
+from pydicom.sr.codedict import codes
+from pydicom.sr.coding import Code
+from pydicom.valuerep import DT, DA, TM
+
+from highdicom.sr.coding import CodedConcept
+from highdicom.sr.enum import ValueTypeValues
+from highdicom.sr.value_types import DateContentItem, DateTimeContentItem, TimeContentItem
+from tests.utils import write_and_read_dataset
+
+
+class TestDateTimeContentItem:
+    test_datetime_values = [
+        DT("2023"),
+        DT("202306"),
+        DT("20230623"),
+        DT("2023062311"),
+        DT("202306231112"),
+        DT("20230623111247"),
+        DT("20230623111247.123456"),
+    ]
+
+    @pytest.mark.parametrize("datetime_value", test_datetime_values)
+    def test_construct_from_datetime(self, datetime_value: DT):
+        name = codes.DCM.DatetimeOfProcessing
+        assert isinstance(name, Code)
+        value_type = ValueTypeValues.DATETIME
+        item = DateTimeContentItem(
+            name=name,
+            value=datetime_value
+        )
+
+        assert item.name == name
+        assert item.value == datetime_value
+        assert item.value_type == value_type
+        assert isinstance(item.value, datetime.datetime)
+        assert item.value.isoformat() == datetime_value.isoformat()
+
+
+    @pytest.mark.parametrize("datetime_value", test_datetime_values)
+    def test_from_dataset(self, datetime_value: DT):
+        name = codes.DCM.DatetimeOfProcessing
+        assert isinstance(name, Code)
+        value_type = ValueTypeValues.DATETIME
+        dataset = Dataset()
+        dataset.ValueType = value_type.value
+        dataset.ConceptNameCodeSequence = [CodedConcept.from_code(name)]
+        dataset.DateTime = datetime_value
+
+        dataset_reread = write_and_read_dataset(dataset)
+        item = DateTimeContentItem.from_dataset(dataset_reread)
+
+        assert item.name == name
+        assert item.value == datetime_value
+        assert item.value_type == value_type
+        assert isinstance(item.value, datetime.datetime)
+        assert item.value.isoformat() == datetime_value.isoformat()
+
+
+class TestDateContentItem:
+    def test_construct_from_date(self):
+        date_value = DA("20230623")
+        name = codes.DCM.AcquisitionDate
+        assert isinstance(name, Code)
+        value_type = ValueTypeValues.DATE
+        item = DateContentItem(
+            name=name,
+            value=date_value
+        )
+
+        assert item.name == name
+        assert item.value == date_value
+        assert item.value_type == value_type
+        assert isinstance(item.value, datetime.date)
+        assert item.value.isoformat() == date_value.isoformat()
+
+
+    def test_from_dataset(self):
+        date_value = DA("20230623")
+        name = codes.DCM.AcquisitionDate
+        assert isinstance(name, Code)
+        value_type = ValueTypeValues.DATE
+        dataset = Dataset()
+        dataset.ValueType = value_type.value
+        dataset.ConceptNameCodeSequence = [CodedConcept.from_code(name)]
+        dataset.Date = date_value
+
+        dataset_reread = write_and_read_dataset(dataset)
+        item = DateContentItem.from_dataset(dataset_reread)
+
+        assert item.name == name
+        assert item.value == date_value
+        assert item.value_type == value_type
+        assert isinstance(item.value, datetime.date)
+        assert item.value.isoformat() == date_value.isoformat()
+
+class TestTimeContentItem:
+    test_time_values = [
+        TM("11"),
+        TM("1112"),
+        TM("111247"),
+        TM("111247.123456"),
+    ]
+
+    @pytest.mark.parametrize("time_value", test_time_values)
+    def test_construct_from_time(self, time_value: TM):
+        name = codes.DCM.AcquisitionTime
+        assert isinstance(name, Code)
+        value_type = ValueTypeValues.TIME
+        item = TimeContentItem(
+            name=name,
+            value=time_value
+        )
+
+        assert item.name == name
+        assert item.value == time_value
+        assert item.value_type == value_type
+        assert isinstance(item.value, datetime.time)
+        assert item.value.isoformat() == time_value.isoformat()
+
+
+    @pytest.mark.parametrize("time_value", test_time_values)
+    def test_from_dataset(self, time_value: TM):
+        name = codes.DCM.AcquisitionDate
+        assert isinstance(name, Code)
+        value_type = ValueTypeValues.TIME
+        dataset = Dataset()
+        dataset.ValueType = value_type.value
+        dataset.ConceptNameCodeSequence = [CodedConcept.from_code(name)]
+        dataset.Time = time_value
+
+        dataset_reread = write_and_read_dataset(dataset)
+        item = TimeContentItem.from_dataset(dataset_reread)
+
+        assert item.name == name
+        assert item.value == time_value
+        assert item.value_type == value_type
+        assert isinstance(item.value, datetime.time)
+        assert item.value.isoformat() == time_value.isoformat()

--- a/tests/test_valuetypes.py
+++ b/tests/test_valuetypes.py
@@ -5,6 +5,7 @@ from pydicom import Dataset
 from pydicom.sr.codedict import codes
 from pydicom.sr.coding import Code
 from pydicom.valuerep import DT, DA, TM
+from pydicom import config
 
 from highdicom.sr.coding import CodedConcept
 from highdicom.sr.enum import ValueTypeValues
@@ -44,7 +45,13 @@ class TestDateTimeContentItem:
         assert item.value.isoformat() == datetime_value.isoformat()
 
     @pytest.mark.parametrize("datetime_value", test_datetime_values)
-    def test_from_dataset(self, datetime_value: DT):
+    @pytest.mark.parametrize("datetime_conversion", [True, False])
+    def test_from_dataset(
+        self,
+        datetime_value: DT,
+        datetime_conversion: bool
+    ):
+        config.datetime_conversion = datetime_conversion
         name = codes.DCM.DatetimeOfProcessing
         assert isinstance(name, Code)
         value_type = ValueTypeValues.DATETIME
@@ -80,7 +87,9 @@ class TestDateContentItem:
         assert isinstance(item.value, datetime.date)
         assert item.value.isoformat() == date_value.isoformat()
 
-    def test_from_dataset(self):
+    @pytest.mark.parametrize("datetime_conversion", [True, False])
+    def test_from_dataset(self, datetime_conversion: bool):
+        config.datetime_conversion = datetime_conversion
         date_value = DA("20230623")
         name = codes.DCM.AcquisitionDate
         assert isinstance(name, Code)
@@ -125,7 +134,13 @@ class TestTimeContentItem:
         assert item.value.isoformat() == time_value.isoformat()
 
     @pytest.mark.parametrize("time_value", test_time_values)
-    def test_from_dataset(self, time_value: TM):
+    @pytest.mark.parametrize("datetime_conversion", [True, False])
+    def test_from_dataset(
+        self,
+        time_value: TM,
+        datetime_conversion: bool
+    ):
+        config.datetime_conversion = datetime_conversion
         name = codes.DCM.AcquisitionDate
         assert isinstance(name, Code)
         value_type = ValueTypeValues.TIME


### PR DESCRIPTION
Hi,

I had some problems with using the 'SpecimenDescription` and `SpecimenPreparationStep` content items:
- The name for the DateTimeContentItem was incorrectly capitalized.
- Datetimes would not parse correctly.
- Some attributes in the [standard ](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.22.html ) were missing.

This PR fixes the above issues and adds tests for the bugs and added parameters. I'm not sureif the approach and style is in line with the rest of the code or if these changes breaks anything else. I'm happy to receive feedback if that is the case.