### PR TITLE
Remove redundant cast

### DIFF
--- a/src/highdicom/ann/content.py
+++ b/src/highdicom/ann/content.py
@@ -233,8 +233,8 @@ class AnnotationGroup(Dataset):
             raise ValueError('Argument "number" must be a positive integer.')
 
         self.AnnotationGroupNumber = number
-        self.AnnotationGroupUID = str(uid)
-        self.AnnotationGroupLabel = str(label)
+        self.AnnotationGroupUID = uid
+        self.AnnotationGroupLabel = label
         if description is not None:
             self.AnnotationGroupDescription = description
 

--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -178,7 +178,7 @@ class SOPClass(Dataset):
         self.PatientSex = patient_sex
 
         # Study
-        self.StudyInstanceUID = str(study_instance_uid)
+        self.StudyInstanceUID = study_instance_uid
         self.AccessionNumber = accession_number
         self.StudyID = study_id
         self.StudyDate = DA(study_date) if study_date is not None else None
@@ -186,7 +186,7 @@ class SOPClass(Dataset):
         self.ReferringPhysicianName = referring_physician_name
 
         # Series
-        self.SeriesInstanceUID = str(series_instance_uid)
+        self.SeriesInstanceUID = series_instance_uid
         if series_number is None:
             raise TypeError('Argument "series_number" is required.')
         if series_number < 1:
@@ -219,8 +219,8 @@ class SOPClass(Dataset):
                 self.InstitutionalDepartmentName = institutional_department_name
 
         # Instance
-        self.SOPInstanceUID = str(sop_instance_uid)
-        self.SOPClassUID = str(sop_class_uid)
+        self.SOPInstanceUID = sop_instance_uid
+        self.SOPClassUID = sop_class_uid
         if instance_number is None:
             raise TypeError('Argument "instance_number" is required.')
         if instance_number < 1:

--- a/src/highdicom/coding_schemes.py
+++ b/src/highdicom/coding_schemes.py
@@ -18,10 +18,10 @@ class CodingSchemeResourceItem(Dataset):
 
         """
         super().__init__()
-        self.CodingSchemeURL = str(url)
+        self.CodingSchemeURL = url
         if url_type not in {"DOC", "OWL", "CSV"}:
             raise ValueError('Unknonw URL type.')
-        self.CodingSchemeURLType = str(url_type)
+        self.CodingSchemeURLType = url_type
 
 
 class CodingSchemeIdentificationItem(Dataset):
@@ -65,16 +65,16 @@ class CodingSchemeIdentificationItem(Dataset):
 
         """  # noqa: E501
         super().__init__()
-        self.CodingSchemeDesignator = str(designator)
+        self.CodingSchemeDesignator = designator
         if name is not None:
-            self.CodingSchemeName = str(name)
+            self.CodingSchemeName = name
         if version is not None:
-            self.CodingSchemeVersion = str(version)
+            self.CodingSchemeVersion = version
         if responsible_organization is not None:
             self.CodingSchemeResponsibleOrganization = \
                 str(responsible_organization)
         if registry is not None:
-            self.CodingSchemeRegistry = str(registry)
+            self.CodingSchemeRegistry = registry
             if uid is None and external_id is None:
                 raise ValueError(
                     'UID or external ID is required if coding scheme is '

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1624,7 +1624,7 @@ class LUT(Dataset):
 
         self.LUTDescriptor = [
             len_data,
-            int(first_mapped_value),
+            first_mapped_value,
             bits_per_entry
         ]
 
@@ -1829,7 +1829,7 @@ class VOILUTTransformation(Dataset):
                         'Argument "window_width" must not be an empty sequence.'
                     )
                 self.WindowWidth = [
-                    format_number_as_ds(float(x)) for x in window_width
+                    format_number_as_ds(x) for x in window_width
                 ]
             else:
                 if window_is_sequence:
@@ -2149,7 +2149,7 @@ class PaletteColorLUT(Dataset):
         setattr(
             self,
             f'{self._attr_name_prefix}Descriptor',
-            [number_of_entries, int(first_mapped_value), bits_per_entry]
+            [number_of_entries, first_mapped_value, bits_per_entry]
         )
 
     @property
@@ -2345,7 +2345,7 @@ class SegmentedPaletteColorLUT(Dataset):
         setattr(
             self,
             f'{self._attr_name_prefix}Descriptor',
-            [number_of_entries, int(first_mapped_value), bits_per_entry]
+            [number_of_entries, first_mapped_value, bits_per_entry]
         )
 
     @property

--- a/src/highdicom/pm/content.py
+++ b/src/highdicom/pm/content.py
@@ -88,8 +88,8 @@ class RealWorldValueMapping(Dataset):
                 f'given {len(lut_label)}.'
             )
 
-        self.LUTExplanation = str(lut_explanation)
-        self.LUTLabel = str(lut_label)
+        self.LUTExplanation = lut_explanation
+        self.LUTLabel = lut_label
 
         is_floating_point = any(isinstance(v, float) for v in value_range)
         if lut_data is not None:
@@ -111,7 +111,7 @@ class RealWorldValueMapping(Dataset):
                     'The LUT data sequence contains wrong number of entries: '
                     f'expected n={n_expected}, actual n={n_actual}.'
                 )
-            self.RealWorldValueLUTData = [float(v) for v in lut_data]
+            self.RealWorldValueLUTData = [v for v in lut_data]
         else:
             if slope is None or intercept is None:
                 raise TypeError(

--- a/src/highdicom/sr/coding.py
+++ b/src/highdicom/sr/coding.py
@@ -35,17 +35,17 @@ class CodedConcept(Dataset):
         super(CodedConcept, self).__init__()
         if len(value) > 16:
             if value.startswith('urn') or '://' in value:
-                self.URNCodeValue = str(value)
+                self.URNCodeValue = value
             else:
-                self.LongCodeValue = str(value)
+                self.LongCodeValue = value
         else:
-            self.CodeValue = str(value)
+            self.CodeValue = value
         if len(meaning) > 64:
             raise ValueError('Code meaning can have maximally 64 characters.')
-        self.CodeMeaning = str(meaning)
-        self.CodingSchemeDesignator = str(scheme_designator)
+        self.CodeMeaning = meaning
+        self.CodingSchemeDesignator = scheme_designator
         if scheme_version is not None:
-            self.CodingSchemeVersion = str(scheme_version)
+            self.CodingSchemeVersion = scheme_version
         # TODO: Enhanced Code Sequence Macro Attributes
 
     def __hash__(self) -> int:

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -809,7 +809,7 @@ class TextContentItem(ContentItem):
         super(TextContentItem, self).__init__(
             ValueTypeValues.TEXT, name, relationship_type
         )
-        self.TextValue = str(value)
+        self.TextValue = value
 
     @property
     def value(self) -> str:
@@ -1859,7 +1859,7 @@ class TcoordContentItem(ContentItem):
         self.TemporalRangeType = temporal_range_type.value
         if referenced_sample_positions is not None:
             self.ReferencedSamplePositions = [
-                int(v) for v in referenced_sample_positions
+                v for v in referenced_sample_positions
             ]
         elif referenced_time_offsets is not None:
             self.ReferencedTimeOffsets = [


### PR DESCRIPTION
Casting a variable to its type hint seems redundant, although it can be seen as defensive programming.