### PR TITLE
Creating a list from a list is equivalent to a copy

### DIFF
--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -2174,7 +2174,7 @@ class Segmentation(SOPClass):
                 f'duplicated referenced SOP Instance UID items: {display_str}.'
             )
 
-        return list(unique_instance_data)
+        return unique_instance_data.copy()
 
     def _build_luts(self) -> None:
         """Build lookup tables for efficient querying.

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -2174,7 +2174,7 @@ class Segmentation(SOPClass):
                 f'duplicated referenced SOP Instance UID items: {display_str}.'
             )
 
-        return unique_instance_data.copy()
+        return unique_instance_data
 
     def _build_luts(self) -> None:
         """Build lookup tables for efficient querying.


### PR DESCRIPTION
In that case, I find calling `.copy()` is more readable.

However, do we really **need** this copy? The list `unique_instance_data` is initialised in this function and then returned. What's the point of copying it?