### PR TITLE
Fix wrong transfer syntax in test

### DIFF
--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -260,7 +260,7 @@ class TestEncodeFrame(TestCase):
         assert compressed_frame.endswith(b'\xFF\xD9')
         decoded_frame = decode_frame(
             value=compressed_frame,
-            transfer_syntax_uid=JPEG2000Lossless,
+            transfer_syntax_uid=JPEGLSLossless,
             rows=frame.shape[0],
             columns=frame.shape[1],
             samples_per_pixel=1,


### PR DESCRIPTION
There is an incorrectly written test that is failing now due to better error checking in the pylibjpeg-openlibjpeg library. The wrong transfer syntax was used for decompression