### PR TITLE
Minor fixes for ANN graphics

### DIFF
--- a/src/highdicom/ann/content.py
+++ b/src/highdicom/ann/content.py
@@ -373,7 +373,7 @@ class AnnotationGroup(Dataset):
         if coordinates.shape[1] == 3:
             unique_z_values = np.unique(coordinates[:, 2])
             if len(unique_z_values) == 1:
-                self.CommonZCoordinateValue = unique_z_values[0]
+                self.CommonZCoordinateValue = unique_z_values.item()
                 coordinates_data = coordinates[:, 0:2].flatten()
                 dimensionality = 2
             else:

--- a/src/highdicom/ann/enum.py
+++ b/src/highdicom/ann/enum.py
@@ -87,12 +87,13 @@ class GraphicTypeValues(Enum):
     """
 
     RECTANGLE = 'RECTANGLE'
-    """Connected line segments defined by three or more ordered coordinates.
+    """Connected line segments defined by four ordered coordinates.
 
-    The coordinates shall be coplanar and form a closed, rectangular polygon.
-    The first coordinate is the top left hand corner, the second coordinate is
-    the top right hand corner, the third coordinate is the bottom right hand
-    corner, and the forth coordinate is the bottom left hand corner.
+    The coordinates shall be coplanar and represent a closed, rectangular
+    polygon. The first coordinate is the top left hand corner, the second
+    coordinate is the top right hand corner, the third coordinate is the bottom
+    right hand corner, and the fourth coordinate is the bottom left hand
+    corner.
 
     The edges of the rectangle need not be aligned with the axes of the
     coordinate system.


### PR DESCRIPTION
Two minor fixes relating to ANNs:

- The docstring for the RECTANGLE GraphicType is confusing and incorrectly states that RECTANGLE may consist of three or more points.
- Setting the CommonZCoordinateValue is giving a pydicom user warning because the expression has type numpy.float32 rather than native python float. Switch to using the `numpy.ndarray.item()` method to get around this