### PR TITLE
Remove references to np.float_

### DIFF
--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -2551,7 +2551,7 @@ class Segmentation(SOPClass):
                     else:
                         segments_overlap = SegmentsOverlapValues.NO
 
-        elif pixel_array.dtype in (np.float_, np.float32, np.float64):
+        elif pixel_array.dtype in (np.float32, np.float64):
             unique_values = np.unique(pixel_array)
             if np.min(unique_values) < 0.0 or np.max(unique_values) > 1.0:
                 raise ValueError(
@@ -2737,7 +2737,7 @@ class Segmentation(SOPClass):
             (0 or 1).
 
         """
-        if pixel_array.dtype in (np.float_, np.float32, np.float64):
+        if pixel_array.dtype in (np.float32, np.float64):
             # Based on the previous checks and casting, if we get here the
             # output is a FRACTIONAL segmentation Floating-point numbers must
             # be mapped to 8-bit integers in the range [0,

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -743,7 +743,7 @@ class TestSegmentation:
         return request.param
 
     @staticmethod
-    @pytest.fixture(params=[np.bool_, np.uint8, np.uint16, np.float_])
+    @pytest.fixture(params=[np.bool_, np.uint8, np.uint16, np.float64])
     def pix_type(request):
         return request.param
 
@@ -1788,7 +1788,7 @@ class TestSegmentation:
             max_fractional_value=max_fractional_value,
             transfer_syntax_uid=fractional_transfer_syntax_uid
         )
-        if pix_type == np.float_:
+        if pix_type == np.float64:
             assert (
                 instance.SegmentsOverlap ==
                 SegmentsOverlapValues.UNDEFINED.value
@@ -1822,7 +1822,7 @@ class TestSegmentation:
             max_fractional_value=max_fractional_value,
             transfer_syntax_uid=fractional_transfer_syntax_uid
         )
-        if pix_type == np.float_:
+        if pix_type == np.float64:
             assert (
                 instance.SegmentsOverlap ==
                 SegmentsOverlapValues.UNDEFINED.value
@@ -2315,7 +2315,7 @@ class TestSegmentation:
         with pytest.raises(ValueError):
             Segmentation(
                 source_images=[self._ct_image],  # empty
-                pixel_array=self._ct_pixel_array.astype(np.float_) * 2,
+                pixel_array=self._ct_pixel_array.astype(np.float64) * 2,
                 segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
                 segment_descriptions=(
                     self._segment_descriptions
@@ -2335,7 +2335,7 @@ class TestSegmentation:
         with pytest.raises(ValueError):
             Segmentation(
                 source_images=[self._ct_image],
-                pixel_array=self._ct_pixel_array.astype(np.float_) * 0.5,
+                pixel_array=self._ct_pixel_array.astype(np.float64) * 0.5,
                 segmentation_type=SegmentationTypeValues.BINARY.value,
                 segment_descriptions=(
                     self._segment_descriptions


### PR DESCRIPTION
`numpy.float_` was deprecated in numpy 2.0.0 in favour of `numpy.float64`