### PR TITLE
Fractional and Multisegment Pyramids

### DIFF
--- a/src/highdicom/seg/pyramid.py
+++ b/src/highdicom/seg/pyramid.py
@@ -77,7 +77,10 @@ def create_segmentation_pyramid(
         List of source images. If there are multiple source images, they should
         be from the same series and pyramid.
     pixel_arrays: Sequence[numpy.ndarray]
-        List of segmentation pixel arrays. Each should be a total pixel matrix.
+        List of segmentation pixel arrays. Each should be a total pixel matrix,
+        i.e. have shape (rows, columns), (1, rows, columns), or (1, rows,
+        columns, segments). Otherwise all options supported by the constructor
+        of :class:`highdicom.seg.Segmentation` are permitted.
     segmentation_type: Union[str, highdicom.seg.SegmentationTypeValues]
         Type of segmentation, either ``"BINARY"`` or ``"FRACTIONAL"``
     segment_descriptions: Sequence[highdicom.seg.SegmentDescription]
@@ -123,16 +126,17 @@ def create_segmentation_pyramid(
         A human readable label for the output pyramid.
     **kwargs: Any
         Any further parameters are passed directly to the constructor of the
-        :class:highdicom.seg.Segmentation object. However the following
+        :class:`highdicom.seg.Segmentation` object. However the following
         parameters are disallowed: ``instance_number``, ``sop_instance_uid``,
         ``plane_orientation``, ``plane_positions``, ``pixel_measures``,
         ``pixel_array``, ``tile_pixel_array``.
 
     Note
     ----
-    Downsampling is performed via simple nearest neighbor interpolation. If
-    more control is needed over the downsampling process (for example
-    anti-aliasing), explicitly pass the downsampled arrays.
+    Downsampling is performed via simple nearest neighbor interpolation (for
+    ``BINARY`` segmentations) or bi-linear interpolation (for ``FRACTIONAL``
+    segmentations). If more control is needed over the downsampling process
+    (for example anti-aliasing), explicitly pass the downsampled arrays.
 
     """
     # Disallow duplicate items in kwargs

--- a/src/highdicom/seg/pyramid.py
+++ b/src/highdicom/seg/pyramid.py
@@ -402,10 +402,13 @@ def create_segmentation_pyramid(
                         int(source_images[0].TotalPixelMatrixRows / f)
                     )
 
-                pixel_array = np.stack(
-                    [np.array(im.resize(output_size, resampler)) for im in mask_images],
-                    axis=-1
-                )[None]
+                resized_masks = [
+                    np.array(im.resize(output_size, resampler)) for im in mask_images
+                ]
+                if len(resized_masks) > 1:
+                    pixel_array = np.stack(resized_masks, axis=-1)[None]
+                else:
+                    pixel_array = resized_masks[0][None]
 
         if n_sources == 1:
             source_pixel_measures = (

--- a/src/highdicom/seg/pyramid.py
+++ b/src/highdicom/seg/pyramid.py
@@ -403,7 +403,8 @@ def create_segmentation_pyramid(
                     )
 
                 resized_masks = [
-                    np.array(im.resize(output_size, resampler)) for im in mask_images
+                    np.array(im.resize(output_size, resampler))
+                    for im in mask_images
                 ]
                 if len(resized_masks) > 1:
                     pixel_array = np.stack(resized_masks, axis=-1)[None]

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -4099,3 +4099,29 @@ class TestPyramid(unittest.TestCase):
                 seg.get_total_pixel_matrix(),
                 pix[0]
             )
+
+    def test_multiple_source_multiple_pixel_arrays_multisegment_labelmap(self):
+        # Test construction when given multiple source images and multiple
+        # segmentation images
+        mask = np.argmax(self._seg_pix_multisegment, axis=3).astype(np.uint8)
+        segs = create_segmentation_pyramid(
+            source_images=self._source_pyramid,
+            pixel_arrays=mask,
+            segmentation_type=SegmentationTypeValues.BINARY,
+            segment_descriptions=self._segment_descriptions_multi,
+            series_instance_uid=UID(),
+            series_number=1,
+            manufacturer='Foo',
+            manufacturer_model_name='Bar',
+            software_versions='1',
+            device_serial_number='123',
+        )
+
+        assert len(segs) == len(self._source_pyramid)
+        for pix, seg in zip(self._downsampled_pix_arrays_multisegment, segs):
+            mask = np.argmax(pix, axis=3).astype(np.uint8)
+            assert hasattr(seg, 'PyramidUID')
+            assert np.array_equal(
+                seg.get_total_pixel_matrix(combine_segments=True),
+                mask[0]
+            )


### PR DESCRIPTION
Currently the `highdicom.seg.create_segmentation_pyramid` function does not correctly support segmentation pixel arrays that are:
- Floating point-valued, and/or
- Contain multiple segments stacked down the last axis

Without API changes, this PR supports these segmentation arrays correctly. Interpolation for fractional segmentations with floating point values is achieved through bi-linear interpolation.