### PR TITLE
Fixes for pydicom 3

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         dependencies: [".", "'.[libjpeg]'"]
 
     steps:

--- a/docs/seg.rst
+++ b/docs/seg.rst
@@ -807,38 +807,37 @@ We recommend that if you do this, you specify ``max_fractional_value=1`` to
 clearly communicate that the segmentation is inherently binary in nature.
 
 Why would you want to make this seemingly rather strange choice? Well,
-``"FRACTIONAL"`` SEGs tend to compress *much* better than ``"BINARY"`` ones
-(see next section). Note however, that this is arguably an misuse of the intent
-of the standard, so *caveat emptor*.
+``"FRACTIONAL"`` SEGs tend to compress better than ``"BINARY"`` ones (see next
+section). Note however, that this is arguably an misuse of the intent of the
+standard, so *caveat emptor*. Also note that while this used to be a more
+serious issue it is less serious now that ``"JPEG2000Lossless"`` compression is
+now supported for ``"BINARY"`` segmentations as of highdicom v0.23.0.
 
 Compression
 -----------
 
 The types of pixel compression available in segmentation images depends on the
-segmentation type. Pixels in a ``"BINARY"`` segmentation image are "bit-packed"
-such that 8 pixels are grouped into 1 byte in the stored array. If a given frame
-contains a number of pixels that is not divisible by 8 exactly, a single byte 
+segmentation type.
+
+Pixels in an uncompressed ``"BINARY"`` segmentation image are "bit-packed" such
+that 8 pixels are grouped into 1 byte in the stored array. If a given frame
+contains a number of pixels that is not divisible by 8 exactly, a single byte
 will straddle a frame boundary into the next frame if there is one, or the byte
 will be padded with zeroes of there are no further frames. This means that
-retrieving individual frames from segmentation images in which each frame
-size is not divisible by 8 becomes problematic. No further compression may be
-applied to frames of ``"BINARY"`` segmentation images.
+retrieving individual frames from segmentation images in which each frame size
+is not divisible by 8 becomes problematic. For this reason, as well as for
+space efficiency (sparse segmentations tend to compress very well), we
+therefore strongly recommend using ``"JPEG2000Lossless"`` compression with
+``"BINRARY"`` segmentations. This is the only compression method currently
+supported for ``"BINARY"`` segmentations. However, beware that reading these
+single-bit JPEG 2000 images may not be supported by all other tools and
+viewers.
 
 Pixels in ``"FRACTIONAL"`` segmentation images may be compressed using one of
 the lossless compression methods available within DICOM. Currently *highdicom*
 supports the following compressed transfer syntaxes when creating
 ``"FRACTIONAL"`` segmentation images: ``"RLELossless"``,
 ``"JPEG2000Lossless"``, and ``"JPEGLSLossless"``.
-
-Note that there may be advantages to using ``"FRACTIONAL"`` segmentations to
-store segmentation images that are binary in nature (i.e. only taking values 0
-and 1):
-
-- If the segmentation is very simple or sparse, the lossless compression methods
-  available in ``"FRACTIONAL"`` images may be more effective than the
-  "bit-packing" method required by ``"BINARY"`` segmentations.
-- The clear frame boundaries make retrieving individual frames from
-  ``"FRACTIONAL"`` image files possible.
 
 Multiprocessing
 ---------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.19",
     "pillow>=8.3",
-    "pydicom>=3.0.0",
+    "pydicom>=3.0.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "highdicom"
 dynamic = ["version"]
 description = "High-level DICOM abstractions."
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.10"
 authors = [
     { name = "Markus D. Herrmann" },
 ]
@@ -24,10 +24,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -38,7 +34,7 @@ dependencies = [
     "numpy>=1.19",
     "pillow-jpls>=1.0",
     "pillow>=8.3",
-    "pydicom>=2.3.0,!=2.4.0",
+    "pydicom>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.19",
-    "pillow-jpls>=1.0",
     "pillow>=8.3",
     "pydicom>=3.0.0",
 ]

--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -139,8 +139,6 @@ class SOPClass(Dataset):
                 "Big Endian transfer syntaxes are retired and no longer "
                 "supported by highdicom."
             )
-        self.is_little_endian = True  # backwards compatibility
-        self.is_implicit_VR = transfer_syntax_uid.is_implicit_VR
 
         # Include all File Meta Information required for writing SOP instance
         # to a file in PS3.10 format.

--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -154,7 +154,6 @@ class SOPClass(Dataset):
             '1.2.826.0.1.3680043.9.7433.1.1'
         )
         self.file_meta.ImplementationVersionName = f'highdicom{__version__}'
-        self.fix_meta_info(enforce_standard=True)
         with BytesIO() as fp:
             write_file_meta_info(fp, self.file_meta, enforce_standard=True)
             self.file_meta.FileMetaInformationGroupLength = len(fp.getvalue())

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -11,7 +11,7 @@ from pydicom.sequence import Sequence as DataElementSequence
 from pydicom.sr.coding import Code
 from pydicom.sr.codedict import codes
 from pydicom.valuerep import DS, format_number_as_ds
-from pydicom._storage_sopclass_uids import SegmentationStorage
+from pydicom.uid import SegmentationStorage
 
 from highdicom.enum import (
     CoordinateSystemNames,

--- a/src/highdicom/frame.py
+++ b/src/highdicom/frame.py
@@ -3,17 +3,20 @@ from io import BytesIO
 from typing import Optional, Union
 
 import numpy as np
+from openjpeg.utils import encode_array
 from PIL import Image
 from pydicom.dataset import Dataset, FileMetaDataset
 from pydicom.encaps import encapsulate
 from pydicom.pixels.utils import pack_bits
-from pydicom.pixels.encoders.base import RLELosslessEncoder
+from pydicom.pixels.encoders.base import get_encoder
 from pydicom.uid import (
     ExplicitVRLittleEndian,
     ImplicitVRLittleEndian,
     JPEG2000Lossless,
+    JPEG2000,
     JPEGBaseline8Bit,
     JPEGLSLossless,
+    JPEGLSNearLossless,
     UID,
     RLELossless,
 )
@@ -51,7 +54,15 @@ def encode_frame(
     bits_stored: int
         Number of bits that are required to store a pixel sample
     photometric_interpretation: Union[PhotometricInterpretationValues, str]
-        Photometric interpretation
+        Photometric interpretation that will be used to store data.  Usually,
+        this will match the photometric interpretation of the input pixel
+        array, however for ``"JPEGBaseline8Bit"``, ``"JPEG2000"``, and
+        ``"JPEG2000Lossless"`` transfer syntaxes with color images, the pixel
+        data must be passed in in RGB format and will be converted and stored
+        as ``"YBR_FULL_422"`` (``"JPEGBaseline8Bit"``), ``"YBR_ICT"``
+        (``"JPEG2000"``), or `"YBR_RCT"`` (``"JPEG2000Lossless"``). In these
+        cases the values of photometric metric passed must match those given
+        above.
     pixel_representation: Union[highdicom.PixelRepresentationValues, int, None], optional
         Whether pixel samples are represented as unsigned integers or
         2's complements
@@ -111,8 +122,10 @@ def encode_frame(
     }
     compressed_transfer_syntaxes = {
         JPEGBaseline8Bit,
+        JPEG2000,
         JPEG2000Lossless,
         JPEGLSLossless,
+        JPEGLSNearLossless,
         RLELossless,
     }
     supported_transfer_syntaxes = uncompressed_transfer_syntaxes.union(
@@ -132,6 +145,16 @@ def encode_frame(
                     'Planar configuration must be 0 for color image frames '
                     'with native encoding.'
                 )
+        allowable_pis = {
+            1: ['MONOCHROME1', 'MONOCHROME2', 'PALETTE_COLOR'],
+            3: ['RGB', 'YBR_FULL'],
+        }[samples_per_pixel]
+        if photometric_interpretation not in allowable_pis:
+            raise ValueError(
+                'Photometric_interpretation of '
+                f"'{photometric_interpretation}' "
+                f'not supported for samples_per_pixel={samples_per_pixel}.'
+            )
         if bits_allocated == 1:
             if (rows * cols * samples_per_pixel) % 8 != 0:
                 raise ValueError(
@@ -142,37 +165,66 @@ def encode_frame(
         else:
             return array.flatten().tobytes()
 
-    else:
-        compression_lut = {
-            JPEGBaseline8Bit: (
-                'jpeg',
-                {
-                    'quality': 95
-                },
-            ),
-            JPEG2000Lossless: (
-                'jpeg2000',
-                {
-                    'tile_size': None,
-                    'num_resolutions': 1,
-                    'irreversible': False,
-                    'no_jp2': True,
-                },
-            ),
-            JPEGLSLossless: (
-                'JPEG-LS',
-                {
-                    'near_lossless': 0,
-                }
+    elif transfer_syntax_uid == JPEGBaseline8Bit:
+        if samples_per_pixel == 1:
+            if planar_configuration is not None:
+                raise ValueError(
+                    'Planar configuration must be absent for encoding of '
+                    'monochrome image frames with JPEG Baseline codec.'
+                )
+            if photometric_interpretation not in (
+                    'MONOCHROME1', 'MONOCHROME2'
+                ):
+                raise ValueError(
+                    'Photometric intpretation must be either "MONOCHROME1" '
+                    'or "MONOCHROME2" for encoding of monochrome image '
+                    'frames with JPEG Baseline codec.'
+                )
+        elif samples_per_pixel == 3:
+            if photometric_interpretation != 'YBR_FULL_422':
+                raise ValueError(
+                    'Photometric intpretation must be "YBR_FULL_422" for '
+                    'encoding of color image frames with '
+                    'JPEG Baseline codec.'
+                )
+            if planar_configuration != 0:
+                raise ValueError(
+                    'Planar configuration must be 0 for encoding of '
+                    'color image frames with JPEG Baseline codec.'
+                )
+        else:
+            raise ValueError(
+                'Samples per pixel must be 1 or 3 for '
+                'encoding of image frames with JPEG Baseline codec.'
             )
-        }
+        if bits_allocated != 8 or bits_stored != 8:
+            raise ValueError(
+                'Bits allocated and bits stored must be 8 for '
+                'encoding of image frames with JPEG Baseline codec.'
+            )
+        if pixel_representation != 0:
+            raise ValueError(
+                'Pixel representation must be 0 for '
+                'encoding of image frames with JPEG Baseline codec.'
+            )
 
-        if transfer_syntax_uid == JPEGBaseline8Bit:
+        # Pydicom does not have an encoder for JPEGBaseline8Bit so
+        # we do this manually
+        if samples_per_pixel == 3:
+            image = Image.fromarray(array, mode='RGB')
+        else:
+            image = Image.fromarray(array)
+        with BytesIO() as buf:
+            image.save(buf, format='jpeg', quality=95)
+            data = buf.getvalue()
+    else:
+        kwargs = {}
+        if transfer_syntax_uid == JPEG2000:
             if samples_per_pixel == 1:
                 if planar_configuration is not None:
                     raise ValueError(
                         'Planar configuration must be absent for encoding of '
-                        'monochrome image frames with JPEG Baseline codec.'
+                        'monochrome image frames with JPEG 2000 codec.'
                     )
                 if photometric_interpretation not in (
                         'MONOCHROME1', 'MONOCHROME2'
@@ -180,35 +232,41 @@ def encode_frame(
                     raise ValueError(
                         'Photometric intpretation must be either "MONOCHROME1" '
                         'or "MONOCHROME2" for encoding of monochrome image '
-                        'frames with JPEG Baseline codec.'
+                        'frames with JPEG 2000 codec.'
+                    )
+                if bits_allocated not in (8, 16):
+                    raise ValueError(
+                        'Bits Allocated must be 8 or 16 for encoding of '
+                        'monochrome image frames with JPEG 2000 codec.'
                     )
             elif samples_per_pixel == 3:
-                if photometric_interpretation != 'YBR_FULL_422':
+                if photometric_interpretation != 'YBR_ICT':
                     raise ValueError(
-                        'Photometric intpretation must be "YBR_FULL_422" for '
+                        'Photometric interpretation must be "YBR_ICT" for '
                         'encoding of color image frames with '
-                        'JPEG Baseline codec.'
+                        'JPEG 2000 codec.'
                     )
                 if planar_configuration != 0:
                     raise ValueError(
                         'Planar configuration must be 0 for encoding of '
-                        'color image frames with JPEG Baseline codec.'
+                        'color image frames with JPEG 2000 codec.'
+                    )
+                if bits_allocated != 8:
+                    raise ValueError(
+                        'Bits Allocated must be 8 for encoding of '
+                        'color image frames with JPEG 2000 codec.'
                     )
             else:
                 raise ValueError(
                     'Samples per pixel must be 1 or 3 for '
-                    'encoding of image frames with JPEG Baseline codec.'
-                )
-            if bits_allocated != 8 or bits_stored != 8:
-                raise ValueError(
-                    'Bits allocated and bits stored must be 8 for '
-                    'encoding of image frames with JPEG Baseline codec.'
+                    'encoding of image frames with JPEG 2000 codec.'
                 )
             if pixel_representation != 0:
                 raise ValueError(
                     'Pixel representation must be 0 for '
-                    'encoding of image frames with JPEG Baseline codec.'
+                    'encoding of image frames with JPEG 2000 codec.'
                 )
+            kwargs = {'j2k_psnr': [100]}
 
         elif transfer_syntax_uid == JPEG2000Lossless:
             if samples_per_pixel == 1:
@@ -225,15 +283,15 @@ def encode_frame(
                         'or "MONOCHROME2" for encoding of monochrome image '
                         'frames with Lossless JPEG 2000 codec.'
                     )
-                if bits_allocated not in (8, 16):
+                if bits_allocated not in (1, 8, 16):
                     raise ValueError(
-                        'Bits Allocated must be 8 or 16 for encoding of '
+                        'Bits Allocated must be 1, 8, or 16 for encoding of '
                         'monochrome image frames with Lossless JPEG 2000 codec.'
                     )
             elif samples_per_pixel == 3:
-                if photometric_interpretation != 'YBR_FULL':
+                if photometric_interpretation != 'YBR_RCT':
                     raise ValueError(
-                        'Photometric interpretation must be "YBR_FULL" for '
+                        'Photometric interpretation must be "YBR_RCT" for '
                         'encoding of color image frames with '
                         'Lossless JPEG 2000 codec.'
                     )
@@ -258,13 +316,16 @@ def encode_frame(
                     'encoding of image frames with Lossless JPEG 2000 codec.'
                 )
 
-        elif transfer_syntax_uid == JPEGLSLossless:
-            import pillow_jpls  # noqa
+        elif transfer_syntax_uid in (JPEGLSLossless, JPEGLSNearLossless):
+            name = {
+                JPEGLSLossless: "Lossless JPEG-LS",
+                JPEGLSNearLossless: "Near-Lossless JPEG-LS",
+            }[transfer_syntax_uid]
             if samples_per_pixel == 1:
                 if planar_configuration is not None:
                     raise ValueError(
                         'Planar configuration must be absent for encoding of '
-                        'monochrome image frames with Lossless JPEG-LS codec.'
+                        f'monochrome image frames with {name} codec.'
                     )
                 if photometric_interpretation not in (
                         'MONOCHROME1', 'MONOCHROME2'
@@ -272,52 +333,67 @@ def encode_frame(
                     raise ValueError(
                         'Photometric intpretation must be either "MONOCHROME1" '
                         'or "MONOCHROME2" for encoding of monochrome image '
-                        'frames with Lossless JPEG-LS codec.'
+                        f'frames with with {name} codec.'
                     )
                 if bits_allocated not in (8, 16):
                     raise ValueError(
                         'Bits Allocated must be 8 or 16 for encoding of '
-                        'monochrome image frames with Lossless JPEG-LS codec.'
+                        f'monochrome image frames with with {name} codec.'
                     )
             elif samples_per_pixel == 3:
-                if photometric_interpretation != 'YBR_FULL':
+                if photometric_interpretation != 'RGB':
                     raise ValueError(
-                        'Photometric interpretation must be "YBR_FULL" for '
+                        'Photometric interpretation must be "RGB" for '
                         'encoding of color image frames with '
-                        'Lossless JPEG-LS codec.'
+                        f'{name} codec.'
                     )
                 if planar_configuration != 0:
                     raise ValueError(
                         'Planar configuration must be 0 for encoding of '
-                        'color image frames with Lossless JPEG-LS codec.'
+                        f'color image frames with {name} codec.'
                     )
                 if bits_allocated != 8:
                     raise ValueError(
                         'Bits Allocated must be 8 for encoding of '
-                        'color image frames with Lossless JPEG-LS codec.'
+                        f'color image frames with {name} codec.'
                     )
             else:
                 raise ValueError(
                     'Samples per pixel must be 1 or 3 for '
-                    'encoding of image frames with Lossless JPEG-LS codec.'
+                    f'encoding of image frames with {name} codec.'
                 )
             if pixel_representation != 0:
                 raise ValueError(
                     'Pixel representation must be 0 for '
-                    'encoding of image frames with Lossless JPEG-LS codec.'
+                    f'encoding of image frames with {name} codec.'
                 )
-
-        if transfer_syntax_uid in compression_lut:
-            image_format, kwargs = compression_lut[transfer_syntax_uid]
-            if samples_per_pixel == 3:
-                image = Image.fromarray(array, mode='RGB')
-            else:
-                image = Image.fromarray(array)
-            with BytesIO() as buf:
-                image.save(buf, format=image_format, **kwargs)
-                data = buf.getvalue()
         elif transfer_syntax_uid == RLELossless:
-            data = RLELosslessEncoder.encode(
+            # No further checks needed
+            pass
+        else:
+            raise ValueError(
+                f'Transfer Syntax "{transfer_syntax_uid}" is not supported.'
+            )
+
+        if transfer_syntax_uid == JPEG2000Lossless and bits_allocated == 1:
+            # Single bit JPEG2000 compression. Pydicom doesn't (yet) support
+            # this case
+            if array.dtype != bool:
+                if array.max() > 1:
+                    raise ValueError(
+                        'Array must contain only 0 and 1 for bits_allocated = 1'
+                    )
+                array = array.astype(bool)
+            data = encode_array(
+                array,
+                bits_stored=1,
+                photometric_interpretation=2,
+                use_mct=False,
+            )
+        else:
+            encoder = get_encoder(transfer_syntax_uid)
+
+            data = encoder.encode(
                 array,
                 rows=array.shape[0],
                 columns=array.shape[1],
@@ -328,10 +404,7 @@ def encode_frame(
                 photometric_interpretation=photometric_interpretation,
                 pixel_representation=pixel_representation,
                 planar_configuration=planar_configuration,
-            )
-        else:
-            raise ValueError(
-                f'Transfer Syntax "{transfer_syntax_uid}" is not supported.'
+                **kwargs,
             )
     return data
 

--- a/src/highdicom/frame.py
+++ b/src/highdicom/frame.py
@@ -6,8 +6,8 @@ import numpy as np
 from PIL import Image
 from pydicom.dataset import Dataset, FileMetaDataset
 from pydicom.encaps import encapsulate
-from pydicom.pixel_data_handlers.numpy_handler import pack_bits
-from pydicom.pixel_data_handlers.rle_handler import rle_encode_frame
+from pydicom.pixels.utils import pack_bits
+from pydicom.pixels.encoders.base import RLELosslessEncoder
 from pydicom.uid import (
     ExplicitVRLittleEndian,
     ImplicitVRLittleEndian,
@@ -317,7 +317,14 @@ def encode_frame(
                 image.save(buf, format=image_format, **kwargs)
                 data = buf.getvalue()
         elif transfer_syntax_uid == RLELossless:
-            data = rle_encode_frame(array)
+            data = RLELosslessEncoder.encode(
+                array,
+                bits_allocated=bits_allocated,
+                bits_stored=bits_stored,
+                photometric_interpretation=photometric_interpretation,
+                pixel_representation=pixel_representation,
+                planar_configuration=planar_configuration,
+            )
         else:
             raise ValueError(
                 f'Transfer Syntax "{transfer_syntax_uid}" is not supported.'

--- a/src/highdicom/frame.py
+++ b/src/highdicom/frame.py
@@ -319,6 +319,10 @@ def encode_frame(
         elif transfer_syntax_uid == RLELossless:
             data = RLELosslessEncoder.encode(
                 array,
+                rows=array.shape[0],
+                columns=array.shape[1],
+                samples_per_pixel=samples_per_pixel,
+                number_of_frames=1,
                 bits_allocated=bits_allocated,
                 bits_stored=bits_stored,
                 photometric_interpretation=photometric_interpretation,

--- a/src/highdicom/frame.py
+++ b/src/highdicom/frame.py
@@ -448,16 +448,4 @@ def decode_frame(
 
     array = ds.pixel_array
 
-    # In case of the JPEG baseline transfer syntax, the pixel_array property
-    # does not convert the pixel data into the correct (or let's say expected)
-    # color space after decompression.
-    if (
-        'YBR' in ds.PhotometricInterpretation and
-        ds.SamplesPerPixel == 3 and
-        transfer_syntax_uid == JPEGBaseline8Bit
-    ):
-        image = Image.fromarray(array, mode='YCbCr')
-        image = image.convert(mode='RGB')
-        array = np.asarray(image)
-
     return array

--- a/src/highdicom/frame.py
+++ b/src/highdicom/frame.py
@@ -218,109 +218,28 @@ def encode_frame(
             image.save(buf, format='jpeg', quality=95)
             data = buf.getvalue()
     else:
+        name = {
+            JPEG2000: "JPEG 2000",
+            JPEG2000Lossless: "Lossless JPEG 2000",
+            JPEGLSLossless: "Lossless JPEG-LS",
+            JPEGLSNearLossless: "Near-Lossless JPEG-LS",
+            RLELossless: "RLE Lossless",
+        }[transfer_syntax_uid]
+
         kwargs = {}
-        if transfer_syntax_uid == JPEG2000:
-            if samples_per_pixel == 1:
-                if planar_configuration is not None:
-                    raise ValueError(
-                        'Planar configuration must be absent for encoding of '
-                        'monochrome image frames with JPEG 2000 codec.'
-                    )
-                if photometric_interpretation not in (
-                        'MONOCHROME1', 'MONOCHROME2'
-                    ):
-                    raise ValueError(
-                        'Photometric intpretation must be either "MONOCHROME1" '
-                        'or "MONOCHROME2" for encoding of monochrome image '
-                        'frames with JPEG 2000 codec.'
-                    )
-                if bits_allocated not in (8, 16):
-                    raise ValueError(
-                        'Bits Allocated must be 8 or 16 for encoding of '
-                        'monochrome image frames with JPEG 2000 codec.'
-                    )
-            elif samples_per_pixel == 3:
-                if photometric_interpretation != 'YBR_ICT':
-                    raise ValueError(
-                        'Photometric interpretation must be "YBR_ICT" for '
-                        'encoding of color image frames with '
-                        'JPEG 2000 codec.'
-                    )
-                if planar_configuration != 0:
-                    raise ValueError(
-                        'Planar configuration must be 0 for encoding of '
-                        'color image frames with JPEG 2000 codec.'
-                    )
-                if bits_allocated != 8:
-                    raise ValueError(
-                        'Bits Allocated must be 8 for encoding of '
-                        'color image frames with JPEG 2000 codec.'
-                    )
-            else:
-                raise ValueError(
-                    'Samples per pixel must be 1 or 3 for '
-                    'encoding of image frames with JPEG 2000 codec.'
-                )
+
+        if samples_per_pixel not in (1, 3):
+            raise ValueError(
+                'Samples per pixel must be 1 or 3 for '
+                f'encoding of image frames with {name} codec.'
+            )
+
+        if transfer_syntax_uid != RLELossless:
             if pixel_representation != 0:
                 raise ValueError(
                     'Pixel representation must be 0 for '
-                    'encoding of image frames with JPEG 2000 codec.'
+                    f'encoding of image frames with {name} codec.'
                 )
-            kwargs = {'j2k_psnr': [100]}
-
-        elif transfer_syntax_uid == JPEG2000Lossless:
-            if samples_per_pixel == 1:
-                if planar_configuration is not None:
-                    raise ValueError(
-                        'Planar configuration must be absent for encoding of '
-                        'monochrome image frames with Lossless JPEG 2000 codec.'
-                    )
-                if photometric_interpretation not in (
-                        'MONOCHROME1', 'MONOCHROME2'
-                    ):
-                    raise ValueError(
-                        'Photometric intpretation must be either "MONOCHROME1" '
-                        'or "MONOCHROME2" for encoding of monochrome image '
-                        'frames with Lossless JPEG 2000 codec.'
-                    )
-                if bits_allocated not in (1, 8, 16):
-                    raise ValueError(
-                        'Bits Allocated must be 1, 8, or 16 for encoding of '
-                        'monochrome image frames with Lossless JPEG 2000 codec.'
-                    )
-            elif samples_per_pixel == 3:
-                if photometric_interpretation != 'YBR_RCT':
-                    raise ValueError(
-                        'Photometric interpretation must be "YBR_RCT" for '
-                        'encoding of color image frames with '
-                        'Lossless JPEG 2000 codec.'
-                    )
-                if planar_configuration != 0:
-                    raise ValueError(
-                        'Planar configuration must be 0 for encoding of '
-                        'color image frames with Lossless JPEG 2000 codec.'
-                    )
-                if bits_allocated != 8:
-                    raise ValueError(
-                        'Bits Allocated must be 8 for encoding of '
-                        'color image frames with Lossless JPEG 2000 codec.'
-                    )
-            else:
-                raise ValueError(
-                    'Samples per pixel must be 1 or 3 for '
-                    'encoding of image frames with Lossless JPEG 2000 codec.'
-                )
-            if pixel_representation != 0:
-                raise ValueError(
-                    'Pixel representation must be 0 for '
-                    'encoding of image frames with Lossless JPEG 2000 codec.'
-                )
-
-        elif transfer_syntax_uid in (JPEGLSLossless, JPEGLSNearLossless):
-            name = {
-                JPEGLSLossless: "Lossless JPEG-LS",
-                JPEGLSNearLossless: "Near-Lossless JPEG-LS",
-            }[transfer_syntax_uid]
             if samples_per_pixel == 1:
                 if planar_configuration is not None:
                     raise ValueError(
@@ -335,45 +254,54 @@ def encode_frame(
                         'or "MONOCHROME2" for encoding of monochrome image '
                         f'frames with with {name} codec.'
                     )
-                if bits_allocated not in (8, 16):
-                    raise ValueError(
-                        'Bits Allocated must be 8 or 16 for encoding of '
-                        f'monochrome image frames with with {name} codec.'
-                    )
+                if transfer_syntax_uid == JPEG2000Lossless:
+                    if bits_allocated not in (1, 8, 16):
+                        raise ValueError(
+                            'Bits Allocated must be 1, 8, or 16 for encoding of '
+                            f'monochrome image frames with with {name} codec.'
+                        )
+                else:
+                    if bits_allocated not in (8, 16):
+                        raise ValueError(
+                            'Bits Allocated must be 8 or 16 for encoding of '
+                            f'monochrome image frames with with {name} codec.'
+                        )
             elif samples_per_pixel == 3:
-                if photometric_interpretation != 'RGB':
-                    raise ValueError(
-                        'Photometric interpretation must be "RGB" for '
-                        'encoding of color image frames with '
-                        f'{name} codec.'
-                    )
                 if planar_configuration != 0:
                     raise ValueError(
                         'Planar configuration must be 0 for encoding of '
                         f'color image frames with {name} codec.'
                     )
-                if bits_allocated != 8:
+                if bits_allocated not in (8, 16):
                     raise ValueError(
-                        'Bits Allocated must be 8 for encoding of '
+                        'Bits Allocated must be 8 or 16 for encoding of '
                         f'color image frames with {name} codec.'
                     )
-            else:
+
+                required_pi = {
+                    JPEG2000: PhotometricInterpretationValues.YBR_ICT,
+                    JPEG2000Lossless: PhotometricInterpretationValues.YBR_RCT,
+                    JPEGLSLossless: PhotometricInterpretationValues.RGB,
+                    JPEGLSNearLossless: PhotometricInterpretationValues.RGB,
+                }[transfer_syntax_uid]
+
+                if photometric_interpretation != required_pi.value:
+                    raise ValueError(
+                        f'Photometric interpretation must be "{required_pi.value}" '
+                        'for encoding of color image frames with '
+                        f'{name} codec.'
+                    )
+
+        if transfer_syntax_uid == JPEG2000:
+            kwargs = {'j2k_psnr': [100]}
+
+        if transfer_syntax_uid in (JPEG2000, JPEG2000Lossless):
+            # This seems to be an openjpeg limitation
+            if array.shape[0] < 32 or array.shape[1] < 32:
                 raise ValueError(
-                    'Samples per pixel must be 1 or 3 for '
-                    f'encoding of image frames with {name} codec.'
+                    'Images smaller than 32 pixels along both dimensions '
+                    f'cannot be encoded with {name} codec.'
                 )
-            if pixel_representation != 0:
-                raise ValueError(
-                    'Pixel representation must be 0 for '
-                    f'encoding of image frames with {name} codec.'
-                )
-        elif transfer_syntax_uid == RLELossless:
-            # No further checks needed
-            pass
-        else:
-            raise ValueError(
-                f'Transfer Syntax "{transfer_syntax_uid}" is not supported.'
-            )
 
         if transfer_syntax_uid == JPEG2000Lossless and bits_allocated == 1:
             # Single bit JPEG2000 compression. Pydicom doesn't (yet) support

--- a/src/highdicom/io.py
+++ b/src/highdicom/io.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import numpy as np
 import pydicom
 from pydicom.dataset import Dataset
-from pydicom.encaps import get_frame_offsets
+from pydicom.encaps import parse_basic_offsets
 from pydicom.filebase import DicomFile, DicomFileLike, DicomBytesIO
 from pydicom.filereader import (
     data_element_offset_to_value,
@@ -120,7 +120,7 @@ def _read_bot(fp: DicomFileLike) -> List[int]:
         fp.is_implicit_VR, 'OB'
     )
     fp.seek(pixel_data_element_value_offset - 4, 1)
-    is_empty, offsets = get_frame_offsets(fp)
+    offsets = parse_basic_offsets(fp)
     return offsets
 
 
@@ -249,7 +249,7 @@ class ImageFileReader:
             DICOM Part10 file containing a dataset of an image SOP Instance
 
         """
-        if isinstance(filename, DicomFileLike):
+        if isinstance(filename, (DicomFileLike, DicomBytesIO)):
             fp = filename
             self._fp = fp
             if isinstance(filename, DicomBytesIO):

--- a/src/highdicom/io.py
+++ b/src/highdicom/io.py
@@ -261,8 +261,8 @@ class ImageFileReader:
             self._fp = None
         else:
             raise TypeError(
-                'Argument "filename" must either an open DICOM file object or '
-                'the path to a DICOM file stored on disk.'
+                'Argument "filename" must be either an open DICOM file object '
+                'or the path to a DICOM file stored on disk.'
             )
         self._metadata = None
 

--- a/src/highdicom/io.py
+++ b/src/highdicom/io.py
@@ -16,7 +16,7 @@ from pydicom.filereader import (
     read_file_meta_info,
     read_partial
 )
-from pydicom.pixel_data_handlers.numpy_handler import unpack_bits
+from pydicom.pixels.utils import unpack_bits
 from pydicom.tag import TupleTag, ItemTag, SequenceDelimiterTag
 from pydicom.uid import UID
 

--- a/src/highdicom/pm/sop.py
+++ b/src/highdicom/pm/sop.py
@@ -664,8 +664,14 @@ class ParametricMap(SOPClass):
             self.PixelRepresentation = 0
         elif pixel_data_type == _PixelDataType.SINGLE:
             self.BitsAllocated = 32
+
+            # This should not be here but is needed to work around pydicom bugs
+            self.BitsStored = self.BitsAllocated
         elif pixel_data_type == _PixelDataType.DOUBLE:
             self.BitsAllocated = 64
+
+            # This should not be here but is needed to work around pydicom bugs
+            self.BitsStored = self.BitsAllocated
         else:
             raise ValueError('Encountered unexpected pixel data type.')
 

--- a/src/highdicom/pm/sop.py
+++ b/src/highdicom/pm/sop.py
@@ -664,14 +664,8 @@ class ParametricMap(SOPClass):
             self.PixelRepresentation = 0
         elif pixel_data_type == _PixelDataType.SINGLE:
             self.BitsAllocated = 32
-
-            # This should not be here but is needed to work around pydicom bugs
-            self.BitsStored = self.BitsAllocated
         elif pixel_data_type == _PixelDataType.DOUBLE:
             self.BitsAllocated = 64
-
-            # This should not be here but is needed to work around pydicom bugs
-            self.BitsStored = self.BitsAllocated
         else:
             raise ValueError('Encountered unexpected pixel data type.')
 

--- a/src/highdicom/pr/sop.py
+++ b/src/highdicom/pr/sop.py
@@ -8,7 +8,7 @@ import numpy as np
 from pydicom import Dataset
 from pydicom.sr.coding import Code
 from pydicom.uid import ExplicitVRLittleEndian
-from pydicom._storage_sopclass_uids import (
+from pydicom.uid import (
     AdvancedBlendingPresentationStateStorage,
     ColorSoftcopyPresentationStateStorage,
     GrayscaleSoftcopyPresentationStateStorage,

--- a/src/highdicom/sc/sop.py
+++ b/src/highdicom/sc/sop.py
@@ -16,8 +16,10 @@ from pydicom.uid import (
     ExplicitVRLittleEndian,
     RLELossless,
     JPEGBaseline8Bit,
+    JPEG2000,
     JPEG2000Lossless,
     JPEGLSLossless,
+    JPEGLSNearLossless,
 )
 
 from highdicom.base import SOPClass
@@ -108,9 +110,17 @@ class SCImage(SOPClass):
             image; either a 2D grayscale image or a 3D color image
             (RGB color space)
         photometric_interpretation: Union[str, highdicom.PhotometricInterpretationValues]
-            Interpretation of pixel data; either ``"MONOCHROME1"`` or
-            ``"MONOCHROME2"`` for 2D grayscale images or ``"RGB"`` or
-            ``"YBR_FULL"`` for 3D color images
+            Interpretation with which to store pixel data in the dataset;
+            either ``"MONOCHROME1"`` or ``"MONOCHROME2"`` for 2D grayscale
+            images or ``"RGB"`` or ``"YBR_FULL"`` for 3D color images. Note
+            that this should match the photometric interpretation of the input
+            pixel array, except in the following cases: if
+            ``transfer_syntax_uid`` is ``"JPEGBaseline8Bit"``,
+            ``photometric_interpretation must be ``"YBR_FULL_422"``, if
+            ``transfer_syntax_uid`` is ``"JPEG2000"``,
+            ``photometric_interpretation must be ``"YBR_ICT"``, if
+            ``transfer_syntax_uid`` is ``"JPEG2000Lossless"``,
+            ``photometric_interpretation must be ``"YBR_RCT"``.
         bits_allocated: int
             Number of bits that should be allocated per pixel value
         coordinate_system: Union[str, highdicom.CoordinateSystemNames]
@@ -188,8 +198,10 @@ class SCImage(SOPClass):
             ExplicitVRLittleEndian,
             RLELossless,
             JPEGBaseline8Bit,
+            JPEG2000,
             JPEG2000Lossless,
             JPEGLSLossless,
+            JPEGLSNearLossless,
         }
         if transfer_syntax_uid not in supported_transfer_syntaxes:
             raise ValueError(
@@ -326,12 +338,23 @@ class SCImage(SOPClass):
             photometric_interpretation
         )
         if pixel_array.ndim == 3:
-            accepted_interpretations = {
-                PhotometricInterpretationValues.RGB.value,
-                PhotometricInterpretationValues.YBR_FULL.value,
-                PhotometricInterpretationValues.YBR_FULL_422.value,
-                PhotometricInterpretationValues.YBR_PARTIAL_420.value,
-            }
+            if transfer_syntax_uid == JPEGBaseline8Bit:
+                accepted_interpretations = {
+                    PhotometricInterpretationValues.YBR_FULL_422.value,
+                }
+            elif transfer_syntax_uid == JPEG2000:
+                accepted_interpretations = {
+                    PhotometricInterpretationValues.YBR_ICT.value,
+                }
+            elif transfer_syntax_uid == JPEG2000Lossless:
+                accepted_interpretations = {
+                    PhotometricInterpretationValues.YBR_RCT.value,
+                }
+            else:
+                accepted_interpretations = {
+                    PhotometricInterpretationValues.RGB.value,
+                    PhotometricInterpretationValues.YBR_FULL.value,
+                }
             if photometric_interpretation.value not in accepted_interpretations:
                 raise ValueError(
                     'Pixel array has an unexpected photometric interpretation.'

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -1634,7 +1634,10 @@ class Segmentation(SOPClass):
         if self.SegmentationType == SegmentationTypeValues.BINARY.value:
             self.BitsAllocated = 1
             self.HighBit = 0
-            if self.file_meta.TransferSyntaxUID.is_encapsulated:
+            if (
+                self.file_meta.TransferSyntaxUID != JPEG2000Lossless and
+                self.file_meta.TransferSyntaxUID.is_encapsulated
+            ):
                 raise ValueError(
                     'The chosen transfer syntax '
                     f'{self.file_meta.TransferSyntaxUID} '

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -29,7 +29,7 @@ from pydicom.dataset import Dataset
 from pydicom.datadict import get_entry, keyword_for_tag, tag_for_keyword
 from pydicom.encaps import encapsulate
 from pydicom.multival import MultiValue
-from pydicom.pixel_data_handlers.numpy_handler import pack_bits
+from pydicom.pixels.utils import pack_bits
 from pydicom.tag import BaseTag, Tag
 from pydicom.uid import (
     ExplicitVRLittleEndian,

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -95,7 +95,9 @@ logger = logging.getLogger(__name__)
 _NO_FRAME_REF_VALUE = -1
 
 # These codes are needed many times in loops so we precompute them
-_DERIVATION_CODE = CodedConcept.from_code(codes.cid7203.Segmentation)
+_DERIVATION_CODE = CodedConcept.from_code(
+    codes.cid7203.SegmentationImageDerivation
+)
 _PURPOSE_CODE = CodedConcept.from_code(
     codes.cid7202.SourceImageForImageProcessingOperation
 )

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -562,7 +562,7 @@ def _get_coded_modality(sop_class_uid: str) -> Code:
         '1.2.840.10008.5.1.4.1.1.14.2': codes.cid29.IntravascularOpticalCoherenceTomography,  # noqa: E501
         '1.2.840.10008.5.1.4.1.1.20': codes.cid29.NuclearMedicine,
         '1.2.840.10008.5.1.4.1.1.66.1': codes.cid32.Registration,
-        '1.2.840.10008.5.1.4.1.1.66.2': codes.cid32.SpatialFiducials,
+        '1.2.840.10008.5.1.4.1.1.66.2': codes.cid32.SpatialFiducialsProducer,
         '1.2.840.10008.5.1.4.1.1.66.3': codes.cid32.Registration,
         '1.2.840.10008.5.1.4.1.1.66.4': codes.cid32.Segmentation,
         '1.2.840.10008.5.1.4.1.1.67': codes.cid32.RealWorldValueMap,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -85,8 +85,6 @@ class TestBase(unittest.TestCase):
             manufacturer='highdicom',
             transfer_syntax_uid=ExplicitVRLittleEndian,
         )
-        assert not sop_class.is_implicit_VR
-        assert sop_class.is_little_endian
 
     def test_implicit_vr(self):
         sop_class = SOPClass(
@@ -100,8 +98,6 @@ class TestBase(unittest.TestCase):
             manufacturer='highdicom',
             transfer_syntax_uid=ImplicitVRLittleEndian,
         )
-        assert sop_class.is_implicit_VR
-        assert sop_class.is_little_endian
 
 
 class TestEndianCheck(unittest.TestCase):

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -4,8 +4,10 @@ from pathlib import Path
 import numpy as np
 import pytest
 from pydicom.uid import (
+    JPEG2000,
     JPEG2000Lossless,
     JPEGLSLossless,
+    JPEGLSNearLossless,
     JPEGBaseline8Bit,
 )
 
@@ -160,14 +162,71 @@ class TestEncodeFrame(TestCase):
 
     def test_jpeg2000_rgb(self):
         bits_allocated = 8
-        frame = np.ones((16, 32, 3), dtype=np.dtype(f'uint{bits_allocated}'))
+        frame = np.ones((48, 32, 3), dtype=np.dtype(f'uint{bits_allocated}'))
+        frame[2:4, 5:30, 0] = 7
+        compressed_frame = encode_frame(
+            frame,
+            transfer_syntax_uid=JPEG2000,
+            bits_allocated=bits_allocated,
+            bits_stored=bits_allocated,
+            photometric_interpretation='YBR_ICT',
+            pixel_representation=0,
+            planar_configuration=0
+        )
+        assert compressed_frame.startswith(b"\xFF\x4F\xFF\x51")
+        assert compressed_frame.endswith(b'\xFF\xD9')
+        decoded_frame = decode_frame(
+            value=compressed_frame,
+            transfer_syntax_uid=JPEG2000,
+            rows=frame.shape[0],
+            columns=frame.shape[1],
+            samples_per_pixel=frame.shape[2],
+            bits_allocated=bits_allocated,
+            bits_stored=bits_allocated,
+            photometric_interpretation='YBR_ICT',
+            pixel_representation=0,
+            planar_configuration=0
+        )
+        np.testing.assert_allclose(frame, decoded_frame, atol=2)
+
+    def test_jpeg2000_monochrome(self):
+        bits_allocated = 8
+        frame = np.zeros((48, 32), dtype=np.dtype(f'uint{bits_allocated}'))
+        frame[2:4, 5:30] = 7
+        compressed_frame = encode_frame(
+            frame,
+            transfer_syntax_uid=JPEG2000,
+            bits_allocated=bits_allocated,
+            bits_stored=bits_allocated,
+            photometric_interpretation='MONOCHROME2',
+            pixel_representation=0,
+        )
+        assert compressed_frame.startswith(b"\xFF\x4F\xFF\x51")
+        assert compressed_frame.endswith(b'\xFF\xD9')
+        decoded_frame = decode_frame(
+            value=compressed_frame,
+            transfer_syntax_uid=JPEG2000,
+            rows=frame.shape[0],
+            columns=frame.shape[1],
+            samples_per_pixel=1,
+            bits_allocated=bits_allocated,
+            bits_stored=bits_allocated,
+            photometric_interpretation='MONOCHROME2',
+            pixel_representation=0,
+            planar_configuration=0
+        )
+        np.testing.assert_allclose(frame, decoded_frame, atol=2)
+
+    def test_jpeg2000lossless_rgb(self):
+        bits_allocated = 8
+        frame = np.ones((48, 32, 3), dtype=np.dtype(f'uint{bits_allocated}'))
         frame *= 255
         compressed_frame = encode_frame(
             frame,
             transfer_syntax_uid=JPEG2000Lossless,
             bits_allocated=bits_allocated,
             bits_stored=bits_allocated,
-            photometric_interpretation='YBR_FULL',
+            photometric_interpretation='YBR_RCT',
             pixel_representation=0,
             planar_configuration=0
         )
@@ -181,15 +240,43 @@ class TestEncodeFrame(TestCase):
             samples_per_pixel=frame.shape[2],
             bits_allocated=bits_allocated,
             bits_stored=bits_allocated,
-            photometric_interpretation='YBR_FULL',
+            photometric_interpretation='YBR_RCT',
             pixel_representation=0,
             planar_configuration=0
         )
         np.testing.assert_array_equal(frame, decoded_frame)
 
-    def test_jpeg2000_monochrome(self):
+    def test_jpeg2000lossless_monochrome(self):
         bits_allocated = 16
-        frame = np.zeros((16, 32), dtype=np.dtype(f'uint{bits_allocated}'))
+        frame = np.zeros((48, 32), dtype=np.dtype(f'uint{bits_allocated}'))
+        compressed_frame = encode_frame(
+            frame,
+            transfer_syntax_uid=JPEG2000Lossless,
+            bits_allocated=bits_allocated,
+            bits_stored=bits_allocated,
+            photometric_interpretation='MONOCHROME2',
+            pixel_representation=0,
+        )
+        assert compressed_frame.startswith(b"\xFF\x4F\xFF\x51")
+        assert compressed_frame.endswith(b'\xFF\xD9')
+        decoded_frame = decode_frame(
+            value=compressed_frame,
+            transfer_syntax_uid=JPEG2000Lossless,
+            rows=frame.shape[0],
+            columns=frame.shape[1],
+            samples_per_pixel=1,
+            bits_allocated=bits_allocated,
+            bits_stored=bits_allocated,
+            photometric_interpretation='MONOCHROME2',
+            pixel_representation=0,
+            planar_configuration=0
+        )
+        np.testing.assert_array_equal(frame, decoded_frame)
+
+    def test_jpeg2000lossless_single_bit(self):
+        bits_allocated = 1
+        frame = np.zeros((48, 32), dtype=np.dtype(f'uint8'))
+        frame[12:45, 3:6] = 1
         compressed_frame = encode_frame(
             frame,
             transfer_syntax_uid=JPEG2000Lossless,
@@ -224,7 +311,7 @@ class TestEncodeFrame(TestCase):
             transfer_syntax_uid=JPEGLSLossless,
             bits_allocated=bits_allocated,
             bits_stored=bits_allocated,
-            photometric_interpretation='YBR_FULL',
+            photometric_interpretation='RGB',
             pixel_representation=0,
             planar_configuration=0
         )
@@ -238,7 +325,7 @@ class TestEncodeFrame(TestCase):
             samples_per_pixel=frame.shape[2],
             bits_allocated=bits_allocated,
             bits_stored=bits_allocated,
-            photometric_interpretation='YBR_FULL',
+            photometric_interpretation='RGB',
             pixel_representation=0,
             planar_configuration=0
         )
@@ -271,6 +358,64 @@ class TestEncodeFrame(TestCase):
             planar_configuration=0
         )
         np.testing.assert_array_equal(frame, decoded_frame)
+
+    def test_jpeglsnearlossless_rgb(self):
+        pytest.importorskip("libjpeg")
+        bits_allocated = 8
+        frame = np.ones((16, 32, 3), dtype=np.dtype(f'uint{bits_allocated}'))
+        frame *= 255
+        compressed_frame = encode_frame(
+            frame,
+            transfer_syntax_uid=JPEGLSNearLossless,
+            bits_allocated=bits_allocated,
+            bits_stored=bits_allocated,
+            photometric_interpretation='RGB',
+            pixel_representation=0,
+            planar_configuration=0
+        )
+        assert compressed_frame.startswith(b'\xFF\xD8')
+        assert compressed_frame.endswith(b'\xFF\xD9')
+        decoded_frame = decode_frame(
+            value=compressed_frame,
+            transfer_syntax_uid=JPEGLSNearLossless,
+            rows=frame.shape[0],
+            columns=frame.shape[1],
+            samples_per_pixel=frame.shape[2],
+            bits_allocated=bits_allocated,
+            bits_stored=bits_allocated,
+            photometric_interpretation='RGB',
+            pixel_representation=0,
+            planar_configuration=0
+        )
+        np.testing.assert_allclose(frame, decoded_frame)
+
+    def test_jpeglsnearlossless_monochrome(self):
+        pytest.importorskip("libjpeg")
+        bits_allocated = 16
+        frame = np.zeros((16, 32), dtype=np.dtype(f'uint{bits_allocated}'))
+        compressed_frame = encode_frame(
+            frame,
+            transfer_syntax_uid=JPEGLSNearLossless,
+            bits_allocated=bits_allocated,
+            bits_stored=bits_allocated,
+            photometric_interpretation='MONOCHROME2',
+            pixel_representation=0,
+        )
+        assert compressed_frame.startswith(b'\xFF\xD8')
+        assert compressed_frame.endswith(b'\xFF\xD9')
+        decoded_frame = decode_frame(
+            value=compressed_frame,
+            transfer_syntax_uid=JPEGLSNearLossless,
+            rows=frame.shape[0],
+            columns=frame.shape[1],
+            samples_per_pixel=1,
+            bits_allocated=bits_allocated,
+            bits_stored=bits_allocated,
+            photometric_interpretation='MONOCHROME2',
+            pixel_representation=0,
+            planar_configuration=0
+        )
+        np.testing.assert_allclose(frame, decoded_frame)
 
     def test_jpeg_rgb_wrong_photometric_interpretation(self):
         frame = np.ones((16, 32, 3), dtype=np.uint8)

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -6,7 +6,7 @@ from typing import Sequence
 import numpy as np
 import pytest
 from pydicom import dcmread
-from pydicom.data import get_testdata_files
+from pydicom.data import get_testdata_file, get_testdata_files
 from pydicom.sr.codedict import codes
 from pydicom.sr.coding import Code
 from pydicom.uid import (
@@ -230,6 +230,10 @@ class TestParametricMap(unittest.TestCase):
 
         self._ct_image = dcmread(
             str(data_dir.joinpath('test_files', 'ct_image.dcm'))
+        )
+
+        self._ct_multiframe_image = dcmread(
+            get_testdata_file('eCT_Supplemental.dcm')
         )
 
         self._sm_image = dcmread(
@@ -549,7 +553,7 @@ class TestParametricMap(unittest.TestCase):
         pixel_array = np.random.randint(
             low=0,
             high=2**8,
-            size=self._sm_image.pixel_array.shape[:3],
+            size=self._ct_multiframe_image.pixel_array.shape[:3],
             dtype=np.uint8
         )
         window_center = 128
@@ -564,7 +568,7 @@ class TestParametricMap(unittest.TestCase):
             slope=1
         )
         pmap = ParametricMap(
-            [self._sm_image],
+            [self._ct_multiframe_image],
             pixel_array,
             self._series_instance_uid,
             self._series_number,

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -341,6 +341,11 @@ class TestParametricMap(unittest.TestCase):
             window_width=window_width,
             content_label=content_label
         )
+
+        # Work around pydicom 3 decoding issue (should be able to remove this
+        # soon)
+        pmap.pixel_array_options(use_v2_backend=True)
+
         assert pmap.SOPClassUID == '1.2.840.10008.5.1.4.1.1.30'
         assert pmap.SOPInstanceUID == self._sop_instance_uid
         assert pmap.SeriesInstanceUID == self._series_instance_uid
@@ -655,6 +660,11 @@ class TestParametricMap(unittest.TestCase):
             window_width=window_width,
         )
         assert pmap.BitsAllocated == 64
+
+        # Work around pydicom 3 decoding issue (should be able to remove this
+        # soon)
+        pmap.pixel_array_options(use_v2_backend=True)
+
         assert np.array_equal(pmap.pixel_array, pixel_array)
 
     def test_single_frame_ct_image_ushort_native(self):
@@ -769,6 +779,10 @@ class TestParametricMap(unittest.TestCase):
             window_center=window_center,
             window_width=window_width,
         )
+
+        # Work around pydicom 3 decoding issue (should be able to remove this
+        # soon)
+        pmap.pixel_array_options(use_v2_backend=True)
 
         assert np.array_equal(pmap.pixel_array, pixel_array)
 

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 import pytest
-from pydicom.encaps import generate_pixel_data_frame
+from pydicom.encaps import generate_fragmented_frames
 from pydicom.filereader import dcmread
 from pydicom.uid import (
     RLELossless,
@@ -67,7 +67,7 @@ class TestSCImage(unittest.TestCase):
                 pixel_representation=ds.PixelRepresentation,
                 planar_configuration=getattr(ds, 'PlanarConfiguration', None)
             )
-            for value in generate_pixel_data_frame(instance.PixelData)
+            for (value, ) in generate_fragmented_frames(instance.PixelData)
         ]
         if len(decoded_frame_arrays) > 1:
             return np.stack(decoded_frame_arrays)

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -725,7 +725,13 @@ class TestSegmentation:
     # Fixtures to use to parametrize segmentation creation
     # Using this fixture mechanism, we can parametrize class methods
     @staticmethod
-    @pytest.fixture(params=[ExplicitVRLittleEndian, ImplicitVRLittleEndian])
+    @pytest.fixture(
+        params=[
+            ExplicitVRLittleEndian,
+            ImplicitVRLittleEndian,
+            JPEG2000Lossless,
+        ]
+    )
     def binary_transfer_syntax_uid(request):
         return request.param
 
@@ -1579,7 +1585,10 @@ class TestSegmentation:
         else:
             omit_empty_frames_values = [False, True]
 
-        transfer_syntax_uids = [ExplicitVRLittleEndian]
+        transfer_syntax_uids = [
+            ExplicitVRLittleEndian,
+            JPEG2000Lossless,
+        ]
         if segmentation_type.value == 'FRACTIONAL':
             try:
                 import libjpeg  # noqa: F401
@@ -1587,7 +1596,6 @@ class TestSegmentation:
                 pass
             else:
                 transfer_syntax_uids += [
-                    JPEG2000Lossless,
                     JPEGLSLossless,
                 ]
 

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -5178,7 +5178,7 @@ class TestImageLibraryEntryDescriptors(unittest.TestCase):
         value_item = group[4].MeasuredValueSequence[0]
         unit_code_item = value_item.MeasurementUnitsCodeSequence[0]
         assert unit_code_item.CodeValue == 'mm'
-        assert unit_code_item.CodeMeaning == 'millimeter'
+        assert unit_code_item.CodeMeaning == 'mm'
         assert unit_code_item.CodingSchemeDesignator == 'UCUM'
         assert isinstance(group[5], NumContentItem)
         assert group[5].name == codes.DCM.VerticalPixelSpacing
@@ -5189,7 +5189,7 @@ class TestImageLibraryEntryDescriptors(unittest.TestCase):
         value_item = group[6].MeasuredValueSequence[0]
         unit_code_item = value_item.MeasurementUnitsCodeSequence[0]
         assert unit_code_item.CodeValue == 'mm'
-        assert unit_code_item.CodeMeaning == 'millimeter'
+        assert unit_code_item.CodeMeaning == 'mm'
         assert unit_code_item.CodingSchemeDesignator == 'UCUM'
         assert isinstance(group[7], NumContentItem)
         assert group[7].name == codes.DCM.SliceThickness

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,15 +7,17 @@ from pydicom.filereader import dcmread
 def write_and_read_dataset(dataset: Dataset):
     """Write DICOM dataset to buffer and read it back from buffer."""
     clone = Dataset(dataset)
-    clone.is_little_endian = True
     if hasattr(dataset, 'file_meta'):
         clone.file_meta = FileMetaDataset(dataset.file_meta)
-        if dataset.file_meta.TransferSyntaxUID == '1.2.840.10008.1.2':
-            clone.is_implicit_VR = True
-        else:
-            clone.is_implicit_VR = False
+        little_endian = None
+        implicit_vr = None
     else:
-        clone.is_implicit_VR = False
+        little_endian = True
+        implicit_vr = True
     with BytesIO() as fp:
-        clone.save_as(fp)
+        clone.save_as(
+            fp,
+            implicit_vr=implicit_vr,
+            little_endian=little_endian,
+        )
         return dcmread(fp, force=True)


### PR DESCRIPTION
The next highdicom release will depend on pydicom>=3. This release of pydicom has several breaking changes that need to be worked around. This branch will address all of them.

In addition to simply fixes, I am enabling some new functionality that is now possible due to enhancements in pydicom:
- JPEG2000 (lossy) and JPEGLSNearLossless are now supported for frame encoding
- JPEG2000Lossless is now supported for single bit images

Finally I am requiring python>=3.10. This is unfortunate since 3.9 is still widely used but since pydicom 3 has this requirement, we are left with little choice I think.

Address #300 
