### PR TITLE
Update docs to reflect python 3.10 dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Installation guide
 Requirements
 ------------
 
-* `Python <https://www.python.org/>`_ (version 3.6 or higher)
+* `Python <https://www.python.org/>`_ (version 3.10 or higher)
 * Python package manager `pip <https://pip.pypa.io/en/stable/>`_
 
 .. _installation:
@@ -35,7 +35,7 @@ a copyleft GPL v3 license, it is not installed by default when you install
 
 .. code-block:: none
 
-    pip install highdicom[libjpeg]
+    pip install 'highdicom[libjpeg]'
 
 Install directly from source code (available on Github):
 


### PR DESCRIPTION
The installation guide was not updated to reflect new python requirements when `v0.23.0` was released