### PR TITLE
Enforce monochrome 2 for input files to legacy conversion

### DIFF
--- a/src/highdicom/legacy/sop.py
+++ b/src/highdicom/legacy/sop.py
@@ -68,6 +68,14 @@ def _convert_legacy_to_enhanced(
             'No data sets of single-frame legacy images provided.'
         ) from e
 
+    if not all(
+        ds.PhotometricInterpretation == 'MONOCHROME2' for ds in sf_datasets
+    ):
+        raise ValueError(
+            "Legacy datasets must have a photometric interpretation of "
+            "'MONOCHROME2'."
+        )
+
     if mf_dataset is None:
         mf_dataset = Dataset()
 


### PR DESCRIPTION
As discussed in #318 (in response to #317), there should be a check to enforce that inputs to the legacy conversion process are MONOCHROME2 images.