### PR TITLE
Enforce series description length

### DIFF
--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -191,6 +191,7 @@ class SOPClass(Dataset):
         self.SeriesNumber = series_number
         self.Modality = modality
         if series_description is not None:
+            _check_long_string(series_description)
             self.SeriesDescription = series_description
 
         # Equipment

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -118,6 +118,7 @@ class TestBase(unittest.TestCase):
                 series_description="abc" * 100,
             )
 
+
 class TestEndianCheck(unittest.TestCase):
 
     def test_big_endian(self):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,3 +1,4 @@
+import re
 import pytest
 import unittest
 
@@ -99,6 +100,23 @@ class TestBase(unittest.TestCase):
             transfer_syntax_uid=ImplicitVRLittleEndian,
         )
 
+    def test_series_description_too_long(self):
+        msg = (
+            "Values of DICOM value representation Long "
+            "String (LO) must not exceed 64 characters."
+        )
+        with pytest.raises(ValueError, match=re.escape(msg)):
+            SOPClass(
+                study_instance_uid=UID(),
+                series_instance_uid=UID(),
+                series_number=1,
+                sop_instance_uid=UID(),
+                sop_class_uid='1.2.840.10008.5.1.4.1.1.88.33',
+                instance_number=1,
+                modality='SR',
+                manufacturer='highdicom',
+                series_description="abc" * 100,
+            )
 
 class TestEndianCheck(unittest.TestCase):
 


### PR DESCRIPTION
Series descriptions are LO (long strings), and as such have constraints on the values (length 64, no backspaces) that are not currently enforced.