### PR TITLE
Allow reading from bytes objects

### DIFF
--- a/src/highdicom/ann/sop.py
+++ b/src/highdicom/ann/sop.py
@@ -12,7 +12,6 @@ from collections.abc import Sequence
 from typing_extensions import Self
 
 import numpy as np
-from pydicom import dcmread
 from pydicom.dataset import Dataset
 from pydicom.sr.coding import Code
 from pydicom.uid import (
@@ -30,6 +29,7 @@ from highdicom.ann.enum import (
 )
 from highdicom.ann.content import AnnotationGroup
 from highdicom.base import SOPClass, _check_little_endian
+from highdicom.io import _wrapped_dcmread
 from highdicom.sr.coding import CodedConcept
 from highdicom.valuerep import check_person_name, _check_code_string
 
@@ -478,6 +478,6 @@ def annread(
 
     """
     return MicroscopyBulkSimpleAnnotations.from_dataset(
-        dcmread(fp),
+        _wrapped_dcmread(fp),
         copy=False
     )

--- a/src/highdicom/image.py
+++ b/src/highdicom/image.py
@@ -15,7 +15,7 @@ from collections.abc import Iterable, Iterator, Generator, Sequence
 from typing_extensions import Self
 
 import numpy as np
-from pydicom import Dataset, dcmread
+from pydicom import Dataset
 from pydicom.encaps import get_frame
 from pydicom.tag import BaseTag
 from pydicom.datadict import (
@@ -37,7 +37,7 @@ from highdicom.enum import (
     CoordinateSystemNames,
 )
 from highdicom.frame import decode_frame
-from highdicom.io import ImageFileReader
+from highdicom.io import ImageFileReader, _wrapped_dcmread
 from highdicom.pixels import (
     _check_rescale_dtype,
     _get_combined_palette_color_lut,
@@ -4791,7 +4791,7 @@ class _Image(SOPClass):
             image = cls.from_dataset(metadata, copy=False)
             image._file_reader = reader
         else:
-            image = cls.from_dataset(dcmread(fp), copy=False)
+            image = cls.from_dataset(_wrapped_dcmread(fp), copy=False)
 
         return image
 

--- a/src/highdicom/image.py
+++ b/src/highdicom/image.py
@@ -22,6 +22,7 @@ from pydicom.datadict import (
     get_entry,
     tag_for_keyword,
 )
+from pydicom.filebase import DicomIO, DicomBytesIO
 from pydicom.multival import MultiValue
 from pydicom.sr.coding import Code
 from pydicom.uid import ParametricMapStorage
@@ -4781,11 +4782,12 @@ class _Image(SOPClass):
 
         """
         if lazy_frame_retrieval:
-            if not isinstance(fp, (str, PathLike)):
-                raise TypeError(
-                    "Argument 'fp' may not be of type bytes or BinaryIO "
-                    "if using 'lazy_frame_retrieval'."
-                )
+            if isinstance(fp, bytes):
+                fp = DicomBytesIO(fp)
+            elif not isinstance(fp, (str, PathLike, DicomIO)):
+                # General BinaryIO object, wrap in DicomIO
+                fp = DicomIO(fp)
+
             reader = ImageFileReader(fp)
             metadata = reader._change_metadata_ownership()
             image = cls.from_dataset(metadata, copy=False)

--- a/src/highdicom/io.py
+++ b/src/highdicom/io.py
@@ -1,5 +1,4 @@
 """Input/Output of datasets based on DICOM Part10 files."""
-from io import BytesIO
 import logging
 from os import PathLike
 import sys
@@ -16,7 +15,7 @@ from pydicom.encaps import parse_basic_offsets
 from pydicom.filebase import (
     DicomBytesIO,
     DicomFile,
-    DicomFileLike,
+    DicomIO,
     ReadableBuffer,
 )
 from pydicom.filereader import (
@@ -66,7 +65,7 @@ def _wrapped_dcmread(
 
     """
     if isinstance(fp, bytes):
-        _fp = BytesIO(fp)
+        _fp = DicomBytesIO(fp)
     else:
         _fp = fp
 
@@ -79,13 +78,13 @@ def _wrapped_dcmread(
     )
 
 
-def _get_bot(fp: DicomFileLike, number_of_frames: int) -> list[int]:
+def _get_bot(fp: DicomIO, number_of_frames: int) -> list[int]:
     """Tries to read the value of the Basic Offset Table (BOT) item and builds
     it in case it is empty.
 
     Parameters
     ----------
-    fp: pydicom.filebase.DicomFileLike
+    fp: pydicom.filebase.DicomIO
         Pointer for DICOM PS3.10 file stream positioned at the first byte of
         the Pixel Data element
     number_of_frames: int
@@ -125,12 +124,12 @@ def _get_bot(fp: DicomFileLike, number_of_frames: int) -> list[int]:
     return basic_offset_table
 
 
-def _read_bot(fp: DicomFileLike) -> list[int]:
+def _read_bot(fp: DicomIO) -> list[int]:
     """Read Basic Offset Table (BOT) item of encapsulated Pixel Data element.
 
     Parameters
     ----------
-    fp: pydicom.filebase.DicomFileLike
+    fp: pydicom.filebase.DicomIO
         Pointer for DICOM PS3.10 file stream positioned at the first byte of
         the Pixel Data element
 
@@ -165,12 +164,12 @@ def _read_bot(fp: DicomFileLike) -> list[int]:
     return offsets
 
 
-def _build_bot(fp: DicomFileLike, number_of_frames: int) -> list[int]:
+def _build_bot(fp: DicomIO, number_of_frames: int) -> list[int]:
     """Build Basic Offset Table (BOT) item of encapsulated Pixel Data element.
 
     Parameters
     ----------
-    fp: pydicom.filebase.DicomFileLike
+    fp: pydicom.filebase.DicomIO
         Pointer for DICOM PS3.10 file stream positioned at the first byte of
         the Pixel Data element following the empty Basic Offset Table (BOT)
     number_of_frames: int
@@ -335,33 +334,41 @@ class ImageFileReader:
 
     """
 
-    def __init__(self, filename: str | Path | DicomFileLike):
+    def __init__(self, filename: str | Path | DicomIO):
         """
         Parameters
         ----------
-        filename: Union[str, pathlib.Path, pydicom.filebase.DicomfileLike]
+        filename: Union[str, pathlib.Path, pydicom.filebase.DicomIO]
             DICOM Part10 file containing a dataset of an image SOP Instance
 
         """
-        if isinstance(filename, (DicomFileLike, DicomBytesIO)):
+        if isinstance(filename, DicomIO):
             fp = filename
             self._fp = fp
-            if isinstance(filename, DicomBytesIO):
-                self._filename = None
-            else:
+            if hasattr(filename, "name") and filename.name is not None:
                 self._filename = Path(fp.name)
+            else:
+                self._filename = None
+
+            # Since we did not open the file-like object, we should not close
+            # it
+            self._should_close = False
         elif isinstance(filename, (str, Path)):
             self._filename = Path(filename)
             self._fp = None
+
+            # Since we did open the file-like object, we should close it
+            self._should_close = True
         else:
             raise TypeError(
-                'Argument "filename" must be either an open DICOM file object '
+                'Argument "filename" must be either an open DicomIO object '
                 'or the path to a DICOM file stored on disk.'
             )
         self._metadata: Dataset | weakref.ReferenceType | None = None
         self._voi_lut = None
         self._palette_color_lut = None
         self._modality_lut = None
+        self._enter_depth = 0
 
     def _change_metadata_ownership(self) -> FileDataset:
         """Set the metadata using a weakref.
@@ -396,24 +403,25 @@ class ImageFileReader:
         return str(self._filename)
 
     def __enter__(self) -> Self:
-        self.open()
+        if self._enter_depth == 0:
+            self.open()
+        self._enter_depth += 1
         return self
 
     def __exit__(self, except_type, except_value, except_trace) -> None:
-        try:
-            self._fp.close()
-        except AttributeError:
-            pass
-        else:
-            self._fp = None
-        if except_value:
-            sys.stderr.write(
-                f'Error while accessing file "{self._filename}":\n'
-                f'{except_value}'
-            )
-            for tb in traceback.format_tb(except_trace):
-                sys.stderr.write(tb)
-            raise
+        self._enter_depth -= 1
+        if self._enter_depth < 1:
+            if self._should_close:
+                self._fp.close()
+                self._fp = None
+            if except_value:
+                sys.stderr.write(
+                    f'Error while accessing file "{self._filename}":\n'
+                    f'{except_value}'
+                )
+                for tb in traceback.format_tb(except_trace):
+                    sys.stderr.write(tb)
+                raise
 
     def open(self) -> None:
         """Open file for reading.
@@ -446,19 +454,21 @@ class ImageFileReader:
                 raise OSError(
                     f'Could not open file for reading: "{self._filename}"'
                 ) from e
-        is_little_endian, is_implicit_VR = self._check_file_format(self._fp)
-        self._fp.is_little_endian = is_little_endian
-        self._fp.is_implicit_VR = is_implicit_VR
+        if not hasattr(self._fp, 'is_implicit_VR'):
+            self._fp.seek(0)
+            is_little_endian, is_implicit_VR = self._check_file_format(self._fp)
+            self._fp.is_little_endian = is_little_endian
+            self._fp.is_implicit_VR = is_implicit_VR
 
     def _check_file_format(
             self,
-            fp: DicomFileLike
+            fp: DicomIO
     ) -> tuple[bool, bool]:
         """Check whether file object represents a DICOM Part 10 file.
 
         Parameters
         ----------
-        fp: pydicom.filebase.DicomFileLike
+        fp: pydicom.filebase.DicomIO
             DICOM file object
 
         Returns
@@ -666,10 +676,11 @@ class ImageFileReader:
 
     def close(self) -> None:
         """Closes file."""
-        try:
-            self._fp.close()
-        except AttributeError:
-            return
+        if self._should_close:
+            try:
+                self._fp.close()
+            except AttributeError:
+                return
 
     def read_frame_raw(self, index: int) -> bytes:
         """Reads the raw pixel data of an individual frame item.
@@ -788,7 +799,7 @@ class ImageFileReader:
     @property
     def number_of_frames(self) -> int:
         """int: Number of frames"""
-        try:
-            return int(self.metadata.NumberOfFrames)
-        except AttributeError:
+        if 'NumberOfFrames' in self.metadata:
+            return self.metadata.NumberOfFrames
+        else:
             return 1

--- a/src/highdicom/spatial.py
+++ b/src/highdicom/spatial.py
@@ -3811,7 +3811,7 @@ def sort_datasets(
 
     Returns
     -------
-    List[Dataset]
+    List[pydicom.Dataset]
         List of datasets sorted according to spatial position, using the
         convention specified by the input parameters.
 

--- a/src/highdicom/sr/sop.py
+++ b/src/highdicom/sr/sop.py
@@ -13,7 +13,6 @@ from typing import (
 from collections.abc import Generator, Mapping, Sequence
 from typing_extensions import Self
 
-from pydicom import dcmread
 from pydicom.dataset import Dataset
 from pydicom.sr.coding import Code
 from pydicom.uid import (
@@ -31,6 +30,7 @@ from pydicom.uid import (
 )
 
 from highdicom.base import SOPClass, _check_little_endian
+from highdicom.io import _wrapped_dcmread
 from highdicom.sr.coding import CodedConcept
 from highdicom.sr.enum import ValueTypeValues
 from highdicom.sr.templates import MeasurementReport
@@ -939,7 +939,7 @@ def srread(
         ComprehensiveSRStorage: ComprehensiveSR,
         Comprehensive3DSRStorage: Comprehensive3DSR,
     }
-    dcm = dcmread(fp)
+    dcm = _wrapped_dcmread(fp)
 
     sop_class_uid = dcm.SOPClassUID
     if sop_class_uid in class_map:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1379,7 +1379,7 @@ def test_imread_from_bytes_io():
 
         assert isinstance(im, Image)
 
-       # Two reads to ensure opening/closing is handled
+        # Two reads to ensure opening/closing is handled
         im.get_frame(1)
         im.get_frame(2)
 
@@ -1392,7 +1392,7 @@ def test_imread_from_bytes_io_lazy():
 
         assert isinstance(im, Image)
 
-       # Two reads to ensure opening/closing is handled
+        # Two reads to ensure opening/closing is handled
         im.get_frame(1)
         im.get_frame(2)
 
@@ -1405,7 +1405,7 @@ def test_imread_from_dicom_bytes_io():
 
         assert isinstance(im, Image)
 
-       # Two reads to ensure opening/closing is handled
+        # Two reads to ensure opening/closing is handled
         im.get_frame(1)
         im.get_frame(2)
 
@@ -1418,6 +1418,6 @@ def test_imread_from_dicom_bytes_io_lazy():
 
         assert isinstance(im, Image)
 
-       # Two reads to ensure opening/closing is handled
+        # Two reads to ensure opening/closing is handled
         im.get_frame(1)
         im.get_frame(2)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,4 +1,5 @@
 """Tests for the highdicom.image module."""
+from io import BytesIO
 from pathlib import Path
 from pydicom.data import get_testdata_file, get_testdata_files
 from pydicom.sr.codedict import codes
@@ -1339,3 +1340,13 @@ def test_imread_all_test_files(f, dependency):
 
     # Perform this check again to check the caching behavior
     assert np.array_equal(im.pixel_array, im_lazy.pixel_array)
+
+
+def test_imread_from_bytes():
+    dcm = pydicom.dcmread(get_testdata_file('eCT_Supplemental.dcm'))
+
+    with BytesIO() as buf:
+        dcm.save_as(buf)
+        im = imread(buf.getvalue())
+
+    assert isinstance(im, Image)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,6 +1,7 @@
 """Tests for the highdicom.image module."""
 from io import BytesIO
 from pathlib import Path
+from pydicom.filebase import DicomBytesIO
 from pydicom.data import get_testdata_file, get_testdata_files
 from pydicom.sr.codedict import codes
 import numpy as np
@@ -1349,4 +1350,74 @@ def test_imread_from_bytes():
         dcm.save_as(buf)
         im = imread(buf.getvalue())
 
-    assert isinstance(im, Image)
+        assert isinstance(im, Image)
+
+        # Two reads to ensure opening/closing is handled
+        im.get_frame(1)
+        im.get_frame(2)
+
+
+def test_imread_from_bytes_lazy():
+    dcm = pydicom.dcmread(get_testdata_file('eCT_Supplemental.dcm'))
+
+    with BytesIO() as buf:
+        dcm.save_as(buf)
+        im = imread(buf.getvalue(), lazy_frame_retrieval=True)
+
+        assert isinstance(im, Image)
+
+        # Two reads to ensure opening/closing is handled
+        im.get_frame(1)
+        im.get_frame(2)
+
+
+def test_imread_from_bytes_io():
+    dcm_bytes = open(get_testdata_file('eCT_Supplemental.dcm'), 'rb').read()
+
+    with BytesIO(dcm_bytes) as buf:
+        im = imread(buf)
+
+        assert isinstance(im, Image)
+
+       # Two reads to ensure opening/closing is handled
+        im.get_frame(1)
+        im.get_frame(2)
+
+
+def test_imread_from_bytes_io_lazy():
+    dcm_bytes = open(get_testdata_file('eCT_Supplemental.dcm'), 'rb').read()
+
+    with BytesIO(dcm_bytes) as buf:
+        im = imread(buf, lazy_frame_retrieval=True)
+
+        assert isinstance(im, Image)
+
+       # Two reads to ensure opening/closing is handled
+        im.get_frame(1)
+        im.get_frame(2)
+
+
+def test_imread_from_dicom_bytes_io():
+    dcm_bytes = open(get_testdata_file('eCT_Supplemental.dcm'), 'rb').read()
+
+    with DicomBytesIO(dcm_bytes) as buf:
+        im = imread(buf)
+
+        assert isinstance(im, Image)
+
+       # Two reads to ensure opening/closing is handled
+        im.get_frame(1)
+        im.get_frame(2)
+
+
+def test_imread_from_dicom_bytes_io_lazy():
+    dcm_bytes = open(get_testdata_file('eCT_Supplemental.dcm'), 'rb').read()
+
+    with DicomBytesIO(dcm_bytes) as buf:
+        im = imread(buf, lazy_frame_retrieval=True)
+
+        assert isinstance(im, Image)
+
+       # Two reads to ensure opening/closing is handled
+        im.get_frame(1)
+        im.get_frame(2)

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 from copy import deepcopy
+from io import BytesIO
 import itertools
 import unittest
 from pathlib import Path
@@ -4173,6 +4174,16 @@ class TestSegmentationParsing:
             'data/test_files/seg_image_sm_control_labelmap_palette_color.dcm'
         )
         assert isinstance(seg, Segmentation)
+
+    def test_segread_from_bytes(self):
+        # Read directly from bytes
+        seg = dcmread('data/test_files/seg_image_ct_binary_overlap.dcm')
+
+        with BytesIO() as buf:
+            seg.save_as(buf)
+            reread_seg = segread(buf.getvalue())
+
+        assert isinstance(reread_seg, Segmentation)
 
     def test_properties(self):
         # SM segs

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -4373,6 +4373,28 @@ class TestComprehensiveSR(unittest.TestCase):
 
         assert isinstance(sr_instance, ComprehensiveSR)
 
+    def test_srread_from_bytes(self):
+        # Read an SR directly from a bytes object
+        report = ComprehensiveSR(
+            evidence=[self._ref_dataset],
+            content=self._content,
+            series_instance_uid=self._series_instance_uid,
+            series_number=self._series_number,
+            sop_instance_uid=self._sop_instance_uid,
+            instance_number=self._instance_number,
+            institution_name=self._institution_name,
+            institutional_department_name=self._department_name,
+            manufacturer=self._manufacturer,
+            performed_procedure_codes=self._performed_procedures,
+        )
+
+        with BytesIO() as buf:
+            report.save_as(buf)
+            # Read from bytes
+            sr_instance = srread(buf.getvalue())
+
+        assert isinstance(sr_instance, ComprehensiveSR)
+
 
 class TestComprehensive3DSR(unittest.TestCase):
 


### PR DESCRIPTION
Fix for #329  to allow `imread`, `segread`, `annread` and `srread` to accept bytes objects of  file contents (except in the case of lazy_frame_retrieval for `imread` and `segread`). The documentation suggested that this was always possible, but it was not. This PR brings the library in line with the documentation