### PR TITLE
Fix ability to read from filelikes with a name property, add docs for reading from S3

### DIFF
--- a/docs/image.rst
+++ b/docs/image.rst
@@ -270,17 +270,18 @@ tiled image:
     # Get a region of the total pixel matrix
     tpm = im.get_total_pixel_matrix(row_end=20)
 
-Whether this saves time depends on your usage patterns and hardware.
-Furthermore in certain situations highdicom needs to parse the entire pixel
-data element in order to determine frame boundaries. This occurs when the
-frames are compressed using an encapsulated transfer syntax but there is no
-offset table giving the locations of frame boundaries within the file. An
-offset table can take the form of either a `basic offset table <BOT>`_ (BOT) at
-the start of the PixelData element or an `extended offset table <EOT>`_ (EOT)
-as a separate attribute in the metadata. These offset tables are not required,
-but often one of them is included in images. Without an offset table, the
-potential speed benefits of using lazy frame retrieval are usually eliminated,
-even if only a small number of frames are loaded.
+Whether this saves time depends on your usage patterns and hardware. It can be
+particularly effective when reading from remote filesystems and cloud storage
+(see :doc:`remote`). Furthermore in certain situations highdicom needs to parse
+the entire pixel data element in order to determine frame boundaries. This
+occurs when the frames are compressed using an encapsulated transfer syntax but
+there is no offset table giving the locations of frame boundaries within the
+file. An offset table can take the form of either a `basic offset table <BOT>`_
+(BOT) at the start of the PixelData element or an `extended offset table
+<EOT>`_ (EOT) as a separate attribute in the metadata. These offset tables are
+not required, but often one of them is included in images. Without an offset
+table, the potential speed benefits of using lazy frame retrieval are usually
+eliminated, even if only a small number of frames are loaded.
 
 .. _BOT: https://dicom.nema.org/dicom/2013/output/chtml/part05/sect_A.4.html
 .. _EOT: http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.3.html#sect_C.7.6.3.1.8

--- a/docs/remote.rst
+++ b/docs/remote.rst
@@ -3,24 +3,34 @@
 Reading from Remote Filesystems
 ===============================
 
-Functions like `dcmread` from pydicom and :meth:`highdicom.imread`,
+Functions like ``dcmread`` from pydicom and :meth:`highdicom.imread`,
 :meth:`highdicom.seg.segread`, :meth:`highdicom.sr.srread`, and
 :meth:`highdicom.ann.annread` from highdicom can read from any object that
 exposes a "file-like" interface. Many alternative and remote filesystems have
-python clients that expose such an interface, and therefore can be read from
+Python clients that expose such an interface, and therefore can be read from
 directly.
-
-One such example is blobs on Google Cloud Storage buckets when accessed using
-the official Python SDK (installed through the ``google-cloud-storage`` PyPI
-package). This is particularly relevant since this is the storage mechanism
-underlying the Imaging Data Commons (`IDC`_), a large repository of
-public DICOM images.
 
 Coupling this with the :ref:`"lazy" frame retrieval <lazy>` option is
 especially powerful, allowing frames to be retrieved from the remote filesystem
 only as and when they are needed. This is particularly useful for large
 multiframe files such as those found in slide microscopy or multi-segment
-binary or fractional segmentations.
+binary or fractional segmentations. However, the presence of offset tables in
+the files is important for this to be effective (see explanation
+in :ref:`lazy`).
+
+Here we give some simple examples of how to do this using two popular cloud
+storage providers: Google Cloud Storage (GCS) and Amazon Web Services (AWS) S3
+storage. These are the two storage mechanisms underlying the Imaging Data
+Commons (`IDC`_), a large repository of public DICOM images. It should be
+possible to achieve the same effect with other filesystems, as long as there is
+a Python client library that exposes a "file-like" interface.
+
+Google Cloud Storage (GCS)
+--------------------------
+
+Blobs within Google Cloud Storage buckets can be accessed through a "file-like"
+interface using the official Python SDK (installed through the
+``google-cloud-storage`` PyPI package).
 
 In this first example, we use lazy frame retrieval to load only a specific
 spatial patch from a large whole slide image from the IDC.
@@ -117,5 +127,65 @@ a `BlobReader`_ object, which has a "file-like" interface
 examples for reading from storage provided by other cloud providers, please
 consider contributing them to this documentation.
 
+Amazon Web Services S3
+----------------------
+
+The `smart_open`_ package wraps an S3 client to expose a "file-like"
+interface for accessing blobs. It can be installed with ``pip install
+'smart_open[s3]'``.
+
+In order to be able to access open IDC data without providing AWS credentials,
+it is necessary to configure your own client object such that it does not
+require signing. This is demonstrated in the following example, which repeats
+the GCS from above using the counterpart of the same blob on AWS S3 (each DICOM
+file in the IDC is stored in two places, one on GSC and the other on S3). If
+you are accessing private files on S3, these steps will be different (consult
+the ``smart_open`` documentation for details).
+
+.. code-block:: python
+
+  import boto3
+  from botocore import UNSIGNED
+  from botocore.config import Config
+  import smart_open
+
+  import numpy as np
+  import highdicom as hd
+  import matplotlib.pyplot as plt
+
+
+  # Configure a client to avoid the need for AWS credentials
+  s3_client = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+
+  # URL to an IDC CT image on AWS S3
+  url = 's3://idc-open-data/763fe058-7d25-4ba7-9b29-fd3d6c41dc4b/210f0529-c767-4795-9acf-bad2f4877427.dcm'
+
+  # Read the imge directly from the blob
+  im = hd.imread(
+      smart_open.open(url, mode="rb", transport_params=dict(client=s3_client)),
+      lazy_frame_retrieval=True,
+  )
+
+  # Grab an arbitrary region of tile full pixel matrix
+  region = im.get_total_pixel_matrix(
+      row_start=15000,
+      row_end=15512,
+      column_start=17000,
+      column_end=17512,
+      dtype=np.uint8
+  )
+
+  # Show the region
+  plt.imshow(region)
+  plt.show()
+
+The ``smart_open`` package can also wrap many other filesystems in this way,
+including Microsoft Azure, Hadoop distributed filesystem (HDFS), gzipped local
+files, files over ssh/scp/sftp, and more. In all cases, be aware that the
+mechanics of the underlying retrieval, as well as configuration such as
+buffering and chunk size, can have a significant impact on the performance of
+lazy frame retrieval.
+
 .. _IDC: https://portal.imaging.datacommons.cancer.gov/
 .. _BlobReader: https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.fileio.BlobReader
+.. _smart_open: https://github.com/piskvorky/smart_open

--- a/src/highdicom/io.py
+++ b/src/highdicom/io.py
@@ -21,8 +21,7 @@ from pydicom.filebase import (
 from pydicom.filereader import (
     data_element_offset_to_value,
     dcmread,
-    read_file_meta_info,
-    read_partial
+    read_partial,
 )
 from pydicom.tag import (
     ItemTag,

--- a/src/highdicom/io.py
+++ b/src/highdicom/io.py
@@ -485,15 +485,12 @@ class ImageFileReader:
             If the file object does not represent a DICOM Part 10 file
 
         """
-        if self._filename is None:
-            # fileobj type is BinaryIO but works fine with a DicomBytesIO
-            file_meta = read_partial(
-                fileobj=fp,  # type: ignore
-                stop_when=_stop_after_group_2
-            ).file_meta
-            fp.seek(0)
-        else:
-            file_meta = read_file_meta_info(str(self._filename))
+        # fileobj type is BinaryIO but works fine with a DicomBytesIO
+        file_meta = read_partial(
+            fileobj=fp,  # type: ignore
+            stop_when=_stop_after_group_2
+        ).file_meta
+        fp.seek(0)
 
         transfer_syntax_uid = UID(file_meta.TransferSyntaxUID)
         return (


### PR DESCRIPTION
Fixes a bug where any "file-like" object that has a "name" property cannot be read from correctly using ImageFileReader. Adds documentation for working with S3 buckets.