### PR TITLE
Set COVERAGE_CORE to speed up tests on 3.12

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -18,6 +18,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         dependencies: [".", "'.[libjpeg]'"]
 
+    env:
+      # Set this otherwise coverage on python 3.12 is absurdly slow
+      COVERAGE_CORE: "sysmon"
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,10 @@ libjpeg = [
     "pylibjpeg>=2.0",
 ]
 test = [
-    "mypy==0.971",
-    "pytest==7.4.4",
-    "pytest-cov==4.1.0",
-    "pytest-flake8==1.1.1",
+    "mypy==1.15.0",
+    "pytest==8.3.5",
+    "pytest-cov==6.1.1",
+    "pytest-flake8==1.3.0",
 ]
 docs = [
     "sphinx-autodoc-typehints==1.17.0",


### PR DESCRIPTION
Github actions has always been extremely slow on Python 3.12 since it was added to the tests.

I tracked this down to the pytest coverage plugin (`pytest-cov`), which in turn appears to be due to problems with the cpython interpreter itself. It really struggles with the huge `_iods.py` and `_modules.py` files, but simple attempts to exclude them from the coverage measurements didn't work (I'm not sure why).

However, setting the environment variable `COVERAGE_CORE=sysmon`  (see [docs](https://coverage.readthedocs.io/en/latest/cmd.html)) improves performance very dramatically.

I also updated the versions of the testing related dependencies