### PR TITLE
Parametric map fixes

### DIFF
--- a/src/highdicom/pm/content.py
+++ b/src/highdicom/pm/content.py
@@ -14,6 +14,10 @@ from highdicom.sr.coding import CodedConcept
 from highdicom.sr.value_types import CodeContentItem
 from highdicom.uid import UID
 from highdicom.utils import compute_plane_position_slide_per_frame
+from highdicom.valuerep import (
+    _check_long_string,
+    _check_short_string,
+)
 
 
 class RealWorldValueMapping(Dataset):
@@ -84,13 +88,9 @@ class RealWorldValueMapping(Dataset):
         """  # noqa: E501
         super().__init__()
 
-        if len(lut_label) > 16:
-            raise ValueError(
-                'lut_label must be less than or equal to 16 characters, '
-                f'given {len(lut_label)}.'
-            )
-
+        _check_long_string(lut_explanation)
         self.LUTExplanation = str(lut_explanation)
+        _check_short_string(lut_label)
         self.LUTLabel = str(lut_label)
 
         is_floating_point = any(isinstance(v, float) for v in value_range)

--- a/src/highdicom/pm/sop.py
+++ b/src/highdicom/pm/sop.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from copy import deepcopy
 from typing import cast
 from collections.abc import Sequence
 from enum import Enum
@@ -614,6 +615,9 @@ class ParametricMap(SOPClass):
                     plane_position_values[last_frame_index, col_index] +
                     self.Columns
                 )
+                self.ImageOrientationSlide = deepcopy(
+                    plane_orientation[0].ImageOrientationSlide
+                )
 
         # Multi-Frame Functional Groups and Multi-Frame Dimensions
         if pixel_measures is None:
@@ -630,7 +634,8 @@ class ParametricMap(SOPClass):
                 )
 
         sffg_item.PixelMeasuresSequence = pixel_measures
-        sffg_item.PlaneOrientationSequence = plane_orientation
+        if coordinate_system == CoordinateSystemNames.PATIENT:
+            sffg_item.PlaneOrientationSequence = plane_orientation
 
         # Identity Pixel Value Transformation
         transformation_item = Dataset()

--- a/src/highdicom/pm/sop.py
+++ b/src/highdicom/pm/sop.py
@@ -17,7 +17,11 @@ from highdicom.enum import ContentQualificationValues, CoordinateSystemNames
 from highdicom.frame import encode_frame
 from highdicom.pm.content import DimensionIndexSequence, RealWorldValueMapping
 from highdicom.pm.enum import DerivedPixelContrastValues, ImageFlavorValues
-from highdicom.valuerep import check_person_name, _check_code_string
+from highdicom.valuerep import (
+    check_person_name,
+    _check_code_string,
+    _check_long_string,
+)
 from highdicom._module_utils import is_multiframe_image
 from pydicom import Dataset
 from pydicom.uid import (
@@ -418,6 +422,8 @@ class ParametricMap(SOPClass):
             self.ContentLabel = content_label
         else:
             self.ContentLabel = 'MAP'
+        if content_description is not None:
+            _check_long_string(content_description)
         self.ContentDescription = content_description
         if content_creator_name is not None:
             check_person_name(content_creator_name)

--- a/src/highdicom/valuerep.py
+++ b/src/highdicom/valuerep.py
@@ -109,6 +109,33 @@ def _check_code_string(value: str) -> None:
         )
 
 
+def _check_short_string(s: str) -> None:
+    """Check that a Python string is valid for use as DICOM Short String.
+
+    Parameters
+    ----------
+    s: str
+        Python string to check.
+
+    Raises
+    ------
+    ValueError:
+        If the string s is not valid as a DICOM Short String due to length or
+        the characters it contains.
+
+    """
+    if len(s) > 16:
+        raise ValueError(
+            'Values of DICOM value representation Short String (SH) must not '
+            'exceed 16 characters.'
+        )
+    if '\\' in s:
+        raise ValueError(
+            'Values of DICOM value representation Short String (SH) must not '
+            'contain the backslash character.'
+        )
+
+
 def _check_long_string(s: str) -> None:
     """Check that a Python string is valid for use as DICOM Long String.
 

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -926,7 +926,6 @@ class TestParametricMap(unittest.TestCase):
         assert len(shared_item.PixelMeasuresSequence) == 1
         pm_item = shared_item.PixelMeasuresSequence[0]
         assert pm_item.PixelSpacing == list(pixel_spacing)
-        assert len(shared_item.PlaneOrientationSequence) == 1
-        po_item = shared_item.PlaneOrientationSequence[0]
-        assert po_item.ImageOrientationSlide == list(image_orientation)
+        assert not hasattr(shared_item, 'PlaneOrientationSequence')
+        assert instance.ImageOrientationSlide == list(image_orientation)
         self.check_dimension_index_vals(instance)


### PR DESCRIPTION
A few fixes for Parametric Map constructtion:

- Checks on the values of a few string attributes
- Move the ImageOrientationSlide attribute to the Data Set root