### PR TITLE
Control numpy output arrays to improve efficiency

### DIFF
--- a/src/highdicom/image.py
+++ b/src/highdicom/image.py
@@ -1349,9 +1349,9 @@ class _Image(SOPClass):
             )
         else:
             if self.number_of_frames == 1:
-                frame = self.pixel_array
+                frame = self.pixel_array.copy()
             else:
-                frame = self.pixel_array[frame_index]
+                frame = self.pixel_array[frame_index].copy()
 
         return frame
 
@@ -1437,9 +1437,9 @@ class _Image(SOPClass):
                     )
                 else:
                     if self.number_of_frames == 1:
-                        frame = self.pixel_array
+                        frame = self.pixel_array.copy()
                     else:
-                        frame = self.pixel_array[frame_index]
+                        frame = self.pixel_array[frame_index].copy()
 
                 output_frames.append(frame)
 

--- a/src/highdicom/pixels.py
+++ b/src/highdicom/pixels.py
@@ -459,7 +459,7 @@ def apply_voi_window(
                 output_min
             )
 
-        array = np.clip(array, output_min, output_max)
+        np.clip(array, output_min, output_max, out=array)
 
     elif voi_lut_function == VOILUTFunctionValues.SIGMOID:
         if invert:

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -3505,7 +3505,11 @@ class Segmentation(_Image):
                             'zeros and the specified MaximumFractionalValue '
                             f'({self.MaximumFractionalValue}).'
                         )
-                    pixel_array = pixel_array // self.MaximumFractionalValue
+                    np.floor_divide(
+                        pixel_array,
+                        self.MaximumFractionalValue,
+                        out=pixel_array,
+                    )
                     if pixel_array.dtype != np.uint8:
                         pixel_array = pixel_array.astype(np.uint8)
 
@@ -3520,9 +3524,23 @@ class Segmentation(_Image):
                             "Cannot combine segments because segments "
                             "overlap."
                         )
-                out_array[output_indexer] = np.maximum(
-                    pixel_array * pix_value,
-                    out_array[output_indexer]
+
+                if pix_value != 1:
+                    if pixel_array.dtype == out_array.dtype:
+                        np.multiply(
+                            pixel_array,
+                            pix_value,
+                            out=pixel_array,
+                            dtype=out_array.dtype,
+                        )
+                    else:
+                        # Allow for casting
+                        pixel_array = pixel_array * pix_value
+
+                np.maximum(
+                    pixel_array,
+                    out_array[output_indexer],
+                    out=out_array[output_indexer]
                 )
 
         else:


### PR DESCRIPTION
Around 10% improvement in efficiency of segmentation reading from specifying numpy output array to reduce allocation of new arrays