### PR TITLE
Add option to use extended offset table

### DIFF
--- a/src/highdicom/pm/sop.py
+++ b/src/highdicom/pm/sop.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from enum import Enum
 
 import numpy as np
-from pydicom.encaps import encapsulate
+from pydicom.encaps import encapsulate, encapsulate_extended
 from highdicom.base import SOPClass
 from highdicom.content import (
     ContentCreatorIdentificationCodeSequence,
@@ -97,6 +97,7 @@ class ParametricMap(SOPClass):
         palette_color_lut_transformation: None | (
             PaletteColorLUTTransformation
         ) = None,
+        use_extended_offset_table: bool = False,
         **kwargs,
     ):
         """
@@ -231,6 +232,14 @@ class ParametricMap(SOPClass):
         palette_color_lut_transformation: Union[highdicom.PaletteColorLUTTransformation, None], optional
             Description of the Palette Color LUT Transformation for transforming
             grayscale into RGB color pixel values
+        use_extended_offset_table: bool, optional
+            Include an extended offset table instead of a basic offset table
+            for encapsulated transfer syntaxes. Extended offset tables avoid
+            size limitations on basic offset tables, and separate the offset
+            table from the pixel data by placing it into metadata. However,
+            they may be less widely supported than basic offset tables. This
+            parameter is ignored if using a native (uncompressed) transfer
+            syntax. The default value may change in a future release.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -770,7 +779,14 @@ class ParametricMap(SOPClass):
 
         self.NumberOfFrames = len(frames)
         if self.file_meta.TransferSyntaxUID.is_encapsulated:
-            pixel_data = encapsulate(frames)
+            if use_extended_offset_table:
+                (
+                    pixel_data,
+                    self.ExtendedOffsetTable,
+                    self.ExtendedOffsetTableLengths,
+                ) = encapsulate_extended(frames)
+            else:
+                pixel_data = encapsulate(frames)
         else:
             pixel_data = b''.join(frames)
         setattr(self, pixel_data_attr, pixel_data)

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -19,7 +19,7 @@ import numpy as np
 from pydicom.dataelem import DataElement
 from pydicom.dataset import Dataset
 from pydicom.datadict import keyword_for_tag, tag_for_keyword
-from pydicom.encaps import encapsulate
+from pydicom.encaps import encapsulate, encapsulate_extended
 from pydicom.pixels.utils import pack_bits
 from pydicom.tag import BaseTag, Tag
 from pydicom.uid import (
@@ -220,6 +220,7 @@ class Segmentation(_Image):
             PaletteColorLUTTransformation
         ) = None,
         icc_profile: bytes | None = None,
+        use_extended_offset_table: bool = False,
         **kwargs: Any
     ) -> None:
         """
@@ -462,6 +463,14 @@ class Segmentation(_Image):
         icc_profile: Union[bytes, None] = None
             An ICC profile to display the segmentation. This is only permitted
             when palette_color_lut_transformation is provided.
+        use_extended_offset_table: bool, optional
+            Include an extended offset table instead of a basic offset table
+            for encapsulated transfer syntaxes. Extended offset tables avoid
+            size limitations on basic offset tables, and separate the offset
+            table from the pixel data by placing it into metadata. However,
+            they may be less widely supported than basic offset tables. This
+            parameter is ignored if using a native (uncompressed) transfer
+            syntax. The default value may change in a future release.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -1671,7 +1680,14 @@ class Segmentation(_Image):
 
             # Encapsulate all pre-compressed frames
             self.NumberOfFrames = len(frames)
-            self.PixelData = encapsulate(frames)
+            if use_extended_offset_table:
+                (
+                    self.PixelData,
+                    self.ExtendedOffsetTable,
+                    self.ExtendedOffsetTableLengths,
+                ) = encapsulate_extended(frames)
+            else:
+                self.PixelData = encapsulate(frames)
         else:
             self.NumberOfFrames = len(frames)
 

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -701,10 +701,13 @@ class TestParametricMap(unittest.TestCase):
             real_world_value_mappings=[real_world_value_mapping],
             window_center=window_center,
             window_width=window_width,
-            transfer_syntax_uid=JPEGLSLossless
+            transfer_syntax_uid=JPEGLSLossless,
+            use_extended_offset_table=True
         )
         assert pmap.BitsAllocated == 16
         assert np.array_equal(pmap.pixel_array, pixel_array)
+        assert hasattr(pmap, 'ExtendedOffsetTable')
+        assert hasattr(pmap, 'ExtendedOffsetTableLengths')
 
     def test_single_frame_ct_image_double(self):
         pixel_array = np.random.uniform(-1, 1, self._ct_image.pixel_array.shape)

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -1680,7 +1680,8 @@ class TestSegmentation:
             self._manufacturer_model_name,
             self._software_versions,
             self._device_serial_number,
-            content_label=self._content_label
+            content_label=self._content_label,
+            transfer_syntax_uid=RLELossless,
         )
         assert instance.SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.7'
         assert (
@@ -1704,6 +1705,8 @@ class TestSegmentation:
         assert not hasattr(instance, 'BluePaletteColorLookupTableData')
         assert instance.PixelPaddingValue == 0
         self.check_dimension_index_vals(instance)
+        assert not hasattr(instance, 'ExtendedOffsetTable')
+        assert not hasattr(instance, 'ExtendedOffsetTableLengths')
 
     def test_construction_9(self):
         # A label with a palette color LUT
@@ -1751,6 +1754,8 @@ class TestSegmentation:
             self._device_serial_number,
             palette_color_lut_transformation=self._lut_transformation,
             icc_profile=self._icc_profile,
+            transfer_syntax_uid=JPEGLSLossless,
+            use_extended_offset_table=True,
         )
         assert instance.SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.7'
         assert instance.PhotometricInterpretation == 'PALETTE COLOR'
@@ -1763,6 +1768,8 @@ class TestSegmentation:
         assert hasattr(instance, 'BluePaletteColorLookupTableData')
         assert instance.PixelPaddingValue == 0
         self.check_dimension_index_vals(instance)
+        assert hasattr(instance, 'ExtendedOffsetTable')
+        assert hasattr(instance, 'ExtendedOffsetTableLengths')
 
     def test_construction_no_coordinate_system(self):
         # This image does have a frame of reference, but no spatial information


### PR DESCRIPTION
Extended offset tables are useful in certain circumstances to avoid size limits or have the offset table retrievable from the metadata alone. This PR adds the option to use an extended offset table (instead of a basic offset table) in the `Segmentation`, `ParametricMap` and `LegacyConverted...` classes