### PR TITLE
Contributing Equipment

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -135,7 +135,7 @@ Computed Tomography (CT) images:
             image_datasets[0].Rows,
             image_datasets[0].Columns
         ),
-        dtype=np.bool
+        dtype=bool
     )
     mask[1:-1, 10:-10, 100:-100] = True
 

--- a/src/highdicom/__init__.py
+++ b/src/highdicom/__init__.py
@@ -8,6 +8,9 @@ from highdicom import sc
 from highdicom import seg
 from highdicom import sr
 from highdicom.base import SOPClass
+from highdicom.base_content import (
+    ContributingEquipment,
+)
 from highdicom.content import (
     AlgorithmIdentificationSequence,
     ContentCreatorIdentificationCodeSequence,
@@ -83,6 +86,7 @@ __all__ = [
     'ChannelDescriptor',
     'ContentCreatorIdentificationCodeSequence',
     'ContentQualificationValues',
+    'ContributingEquipment',
     'CoordinateSystemNames',
     'DimensionOrganizationTypeValues',
     'Image',

--- a/src/highdicom/ann/sop.py
+++ b/src/highdicom/ann/sop.py
@@ -147,22 +147,6 @@ class MicroscopyBulkSimpleAnnotations(SOPClass):
                 f'Transfer syntax "{transfer_syntax_uid}" is not supported.'
             )
 
-        try:
-            acquisition_equipment = (
-                ContributingEquipment.for_image_acquisition(src_img)
-            )
-        except Exception:
-            pass
-        else:
-            if contributing_equipment is None:
-                contributing_equipment = []
-            else:
-                contributing_equipment = list(contributing_equipment)
-            contributing_equipment = [
-                acquisition_equipment,
-                *list(contributing_equipment),
-            ]
-
         super().__init__(
             study_instance_uid=src_img.StudyInstanceUID,
             series_instance_uid=series_instance_uid,
@@ -187,11 +171,11 @@ class MicroscopyBulkSimpleAnnotations(SOPClass):
             manufacturer_model_name=manufacturer_model_name,
             device_serial_number=device_serial_number,
             software_versions=software_versions,
-            contributing_equipment=contributing_equipment,
             **kwargs
         )
         self.copy_specimen_information(src_img)
         self.copy_patient_and_study_information(src_img)
+        self._add_contributing_equipment(contributing_equipment, src_img)
 
         # Microscopy Bulk Simple Annotations
         if content_label is not None:

--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -6,10 +6,12 @@ from collections.abc import Sequence
 from pydicom.datadict import tag_for_keyword
 from pydicom.dataset import Dataset, FileMetaDataset
 from pydicom.filewriter import write_file_meta_info
+from pydicom.sr.codedict import codes
 from pydicom.uid import ImplicitVRLittleEndian, UID
 from pydicom.valuerep import DA, PersonName, TM
 
 from highdicom.coding_schemes import CodingSchemeIdentificationItem
+from highdicom.base_content import ContributingEquipment
 from highdicom.enum import (
     ContentQualificationValues,
     PatientSexValues,
@@ -58,6 +60,7 @@ class SOPClass(Dataset):
         device_serial_number: str | None = None,
         institution_name: str | None = None,
         institutional_department_name: str | None = None,
+        contributing_equipment: Sequence[ContributingEquipment] | None = None,
     ):
         """
         Parameters
@@ -213,6 +216,35 @@ class SOPClass(Dataset):
             if institutional_department_name is not None:
                 _check_long_string(institutional_department_name)
                 self.InstitutionalDepartmentName = institutional_department_name
+
+        # ContributingEquipment (SOP Common)
+        if contributing_equipment is None:
+            contributing_equipment = []
+        else:
+            contributing_equipment = list(contributing_equipment)
+
+        for item in contributing_equipment:
+            if not isinstance(item, ContributingEquipment):
+                raise TypeError(
+                    "Items of argument 'contributing_equipment' must be of "
+                    'type highdicom.ContributingEquipment.'
+                )
+
+        equipment_code = None
+        if sop_class_uid in (
+            '1.2.840.10008.5.1.4.1.1.4.4',    # LegacyConvertedEnhancedMRImage
+            '1.2.840.10008.5.1.4.1.1.2.2',    # LegacyConvertedEnhancedCTImage
+            '1.2.840.10008.5.1.4.1.1.128.1',  # LegacyConvertedEnhancedPETImage
+        ):
+            equipment_code = codes.DCM.EnhancedMultiFrameConversionEquipment
+
+        contributing_equipment.append(
+            ContributingEquipment.for_highdicom(
+                purpose_of_reference=equipment_code
+            )
+        )
+
+        self.ContributingEquipmentSequence = contributing_equipment
 
         # Instance
         self.SOPInstanceUID = str(sop_instance_uid)

--- a/src/highdicom/base_content.py
+++ b/src/highdicom/base_content.py
@@ -1,0 +1,255 @@
+"""Module containing content required by the base SOPClass."""
+import datetime
+from typing import Sequence
+from typing_extensions import Self
+
+from pydicom.dataset import Dataset
+from pydicom.sr.coding import Code
+from pydicom.sr.codedict import codes
+from pydicom.valuerep import DT
+
+from highdicom.version import __version__
+from highdicom.sr.coding import CodedConcept
+from highdicom.valuerep import (
+    _check_long_string,
+    _check_short_string,
+    _check_short_text,
+)
+from highdicom._module_utils import (
+    does_iod_have_pixel_data,
+)
+
+
+class ContributingEquipment(Dataset):
+
+    """Data Set representing an item of the ContributingEquipmentSequence.
+
+    Contains descriptive attributes of related equipment that has contributed
+    to the acquisition, creation or modification of a DICOM Instance.
+
+    """
+
+    def __init__(
+        self,
+        manufacturer: str,
+        purpose_of_reference: Code | CodedConcept,
+        *,
+        manufacturer_model_name: str | None = None,
+        software_versions: str | Sequence[str] | None = None,
+        device_serial_number: str | None = None,
+        institution_name: str | None = None,
+        institutional_department_name: str | None = None,
+        institution_address: str | None = None,
+        station_name: str | None = None,
+        contribution_datetime: str | datetime.datetime | DT | None = None,
+        contribution_description: str | None = None,
+    ):
+        """
+
+        Parameters
+        ----------
+        manufacturer: str
+            Manufacturer of the equipment that contributed.
+        purpose_of_reference: pydicom.sr.coding.Code | highdicom.sr.CodedConcept
+            The purpose for which the related equipment is being referenced.
+            This must be one of the following codes from the DCM terminology:
+            SynthesizingEquipment, AcquisitionEquipment, ProcessingEquipment,
+            ModifyingEquipment, DeIdentifyingEquipment,
+            FrameExtractingEquipment, EnhancedMultiFrameConversionEquipment.
+        manufacturer_model_name: str | None, optional
+            Manufacturer's model name of the equipment that contributed.
+        software_versions: str | Sequence[str] | None, optional
+            Manufacturer's designation of the software version of the equipment
+            that contributed.
+        device_serial_number: str | None, optional
+            Manufacturer's serial number of the equipment that contributed.
+        institution_name: str | None, optional
+            Institution where the equipment that contributed is located.
+        institutional_department_name: str | None, optional
+            Department in the institution where the equipment that contributed
+            is located.
+        institution_address: str | None, optional
+            Address of the institution where the equipment that contributed
+            is located.
+        station_name: str | None, optional
+            User defined name identifying the machine that contributed.
+        contribution_datetime: str | datetime.datetime | DT | None, optional
+            The date & time when the equipment contributed.
+        contribution_description: str | None, optional
+            Description of the contribution the equipment made.
+
+        """
+        super().__init__()
+
+        _check_long_string(manufacturer)
+        self.Manufacturer = manufacturer
+
+        allowed_reference_codes = (
+            codes.DCM.SynthesizingEquipment,
+            codes.DCM.AcquisitionEquipment,
+            codes.DCM.ProcessingEquipment,
+            codes.DCM.ModifyingEquipment,
+            codes.DCM.DeIdentifyingEquipment,
+            codes.DCM.FrameExtractingEquipment,
+            codes.DCM.EnhancedMultiFrameConversionEquipment,
+        )
+
+        if not isinstance(purpose_of_reference, CodedConcept):
+            purpose_of_reference = CodedConcept.from_code(purpose_of_reference)
+        if purpose_of_reference not in allowed_reference_codes:
+            raise ValueError(
+                "Argument 'purpose_of_reference' has an invalid value."
+            )
+        self.PurposeOfReferenceCodeSequence = [purpose_of_reference]
+
+        if manufacturer_model_name is not None:
+            _check_long_string(manufacturer_model_name)
+            self.ManufacturerModelName = manufacturer_model_name
+
+        if institution_name is not None:
+            _check_long_string(institution_name)
+            self.InstitutionName = institution_name
+
+        if institutional_department_name is not None:
+            _check_long_string(institutional_department_name)
+            self.InstitutionalDepartmentName = institutional_department_name
+
+        if institution_address is not None:
+            _check_short_text(institution_address)
+            self.InstitutionAddress = institution_address
+
+        if station_name is not None:
+            _check_short_string(station_name)
+            self.StationName = station_name
+
+        if device_serial_number is not None:
+            _check_long_string(device_serial_number)
+            self.DeviceSerialNumber = device_serial_number
+
+        if software_versions is not None:
+            if isinstance(software_versions, str):
+                _check_long_string(software_versions)
+            else:
+                software_versions = list(software_versions)
+                if len(software_versions) == 0:
+                    raise ValueError(
+                        "Argument 'software_versions' must not be empty."
+                    )
+                for item in software_versions:
+                    _check_long_string(item)
+            self.SoftwareVersions = software_versions
+
+        if contribution_datetime is not None:
+            self.ContributionDateTime = DT(contribution_datetime)
+
+        if contribution_description is not None:
+            _check_short_text(contribution_description)
+            self.ContributionDescription = contribution_description
+
+    @classmethod
+    def for_image_acquisition(
+        cls,
+        dataset: Dataset,
+    ) -> Self:
+        """Create an item describing image acquisition of a given image dataset.
+
+        Parameters
+        ----------
+        dataset: pydicom.Dataset
+            Image dataset.
+
+        Returns
+        -------
+        highdicom.ContributingEquipment:
+            Contributing equipment object describing the acquisition of the
+            image in the provided dataset.
+
+        Raises
+        ------
+        ValueError:
+            If the dataset does not represent an image.
+        AttributeError:
+            If the dataset does not contain the Manufacturer attribute, or it
+            is empty.
+
+        """
+        if not does_iod_have_pixel_data(dataset.SOPClassUID):
+            raise ValueError("Dataset does not represent an Image.")
+
+        manufacturer = dataset.get('Manufacturer')  # NB type 2
+
+        if manufacturer is None or manufacturer == '':
+            raise AttributeError('Dataset has no manufacturer information.')
+
+        manufacturer_model_name = dataset.get('ManufacturerModelName')
+        software_versions = dataset.get('SoftwareVersions')
+        device_serial_number = dataset.get('DeviceSerialNumber')
+        institution_name = dataset.get('InstitutionName')
+        institutional_department_name = dataset.get(
+            'InstitutionalDepartmentName'
+        )
+        institution_address = dataset.get('InstitutionAddress')
+        station_name = dataset.get('StationName')
+        contribution_description = (
+            'Acquisition equipment of the source image(s)'
+        )
+
+        contribution_datetime = dataset.get('AcquisitionDateTime')
+
+        if contribution_datetime is None:
+            date = dataset.get('AcquisitionDate')
+            time = dataset.get('AcquisitionTime')
+            if (
+                isinstance(date, datetime.date) and
+                isinstance(time, datetime.time)
+            ):
+                contribution_datetime = datetime.datetime.combine(
+                    dataset.AcquisitionDate, dataset.AcquisitionTime
+                )
+
+        return cls(
+            manufacturer=manufacturer,
+            purpose_of_reference=codes.DCM.AcquisitionEquipment,
+            manufacturer_model_name=manufacturer_model_name,
+            software_versions=software_versions,
+            device_serial_number=device_serial_number,
+            institution_name=institution_name,
+            institutional_department_name=institutional_department_name,
+            institution_address=institution_address,
+            station_name=station_name,
+            contribution_datetime=contribution_datetime,
+            contribution_description=contribution_description,
+        )
+
+    @classmethod
+    def for_highdicom(
+        cls,
+        *,
+        purpose_of_reference: Code | CodedConcept | None = None,
+    ) -> Self:
+        """Create an item describing highdicom's contribution to the instance.
+
+        Parameters
+        ----------
+        purpose_of_reference: pydicom.sr.coding.Code | highdicom.sr.CodedConcept | None, optional
+            The purpose for which the related equipment is being referenced.
+            This must be one of the following codes from the DCM terminology:
+            SynthesizingEquipment, AcquisitionEquipment, ProcessingEquipment,
+            ModifyingEquipment, DeIdentifyingEquipment,
+            FrameExtractingEquipment, EnhancedMultiFrameConversionEquipment.
+            If ``None``, ProcessingEquipment will be used.
+
+        """  # noqa: E501
+        if purpose_of_reference is None:
+            purpose_of_reference = codes.DCM.ProcessingEquipment
+
+        return cls(
+            manufacturer='Highdicom open-source contributors',
+            manufacturer_model_name='highdicom',
+            contribution_datetime=datetime.datetime.now(),
+            software_versions=__version__,
+            purpose_of_reference=purpose_of_reference,
+            contribution_description=(
+                'Software library used to create this instance'
+            ),
+        )

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -45,7 +45,7 @@ from highdicom.uid import UID
 from highdicom.valuerep import (
     _check_long_string,
     _check_long_text,
-    _check_short_text
+    _check_short_text,
 )
 from highdicom._module_utils import (
     check_required_attributes,

--- a/src/highdicom/ko/sop.py
+++ b/src/highdicom/ko/sop.py
@@ -125,9 +125,9 @@ class KeyObjectSelectionDocument(SOPClass):
             referring_physician_name=getattr(
                 evidence[0], 'ReferringPhysicianName', None
             ),
-            contributing_equipment=contributing_equipment,
             **kwargs
         )
+        self._add_contributing_equipment(contributing_equipment)
 
         if institution_name is not None:
             self.InstitutionName = institution_name

--- a/src/highdicom/ko/sop.py
+++ b/src/highdicom/ko/sop.py
@@ -16,6 +16,7 @@ from pydicom.uid import (
 )
 
 from highdicom.base import SOPClass, _check_little_endian
+from highdicom.base_content import ContributingEquipment
 from highdicom.sr.utils import collect_evidence
 from highdicom.sr.value_types import ContainerContentItem
 from highdicom.ko.content import KeyObjectSelection
@@ -40,6 +41,9 @@ class KeyObjectSelectionDocument(SOPClass):
         institutional_department_name: str | None = None,
         requested_procedures: Sequence[Dataset] | None = None,
         transfer_syntax_uid: str | UID = ExplicitVRLittleEndian,
+        contributing_equipment: Sequence[
+            ContributingEquipment
+        ] | None = None,
         **kwargs: Any
     ) -> None:
         """
@@ -75,6 +79,9 @@ class KeyObjectSelectionDocument(SOPClass):
         transfer_syntax_uid: str, optional
             UID of transfer syntax that should be used for encoding of
             data elements.
+        contributing_equipment: Sequence[highdicom.ContributingEquipment] | None, optional
+            Additional equipment that has contributed to the acquisition,
+            creation or modification of this instance.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -118,6 +125,7 @@ class KeyObjectSelectionDocument(SOPClass):
             referring_physician_name=getattr(
                 evidence[0], 'ReferringPhysicianName', None
             ),
+            contributing_equipment=contributing_equipment,
             **kwargs
         )
 

--- a/src/highdicom/pm/sop.py
+++ b/src/highdicom/pm/sop.py
@@ -331,22 +331,6 @@ class ParametricMap(SOPClass):
         if pixel_array.ndim == 2:
             pixel_array = pixel_array[np.newaxis, ...]
 
-        try:
-            acquisition_equipment = (
-                ContributingEquipment.for_image_acquisition(src_img)
-            )
-        except Exception:
-            pass
-        else:
-            if contributing_equipment is None:
-                contributing_equipment = []
-            else:
-                contributing_equipment = list(contributing_equipment)
-            contributing_equipment = [
-                acquisition_equipment,
-                *list(contributing_equipment),
-            ]
-
         # There are different DICOM Attributes in the SOP instance depending
         # on what type of data is being saved. This lets us keep track of that
         # a bit easier
@@ -380,7 +364,6 @@ class ParametricMap(SOPClass):
             manufacturer_model_name=manufacturer_model_name,
             device_serial_number=device_serial_number,
             software_versions=software_versions,
-            contributing_equipment=contributing_equipment,
             **kwargs,
         )
 
@@ -754,6 +737,7 @@ class ParametricMap(SOPClass):
 
         self.copy_specimen_information(src_img)
         self.copy_patient_and_study_information(src_img)
+        self._add_contributing_equipment(contributing_equipment, src_img)
 
         dimension_position_values = [
             np.unique(plane_position_values[:, index], axis=0)

--- a/src/highdicom/pr/sop.py
+++ b/src/highdicom/pr/sop.py
@@ -17,6 +17,7 @@ from pydicom.uid import (
 from pydicom.valuerep import PersonName
 
 from highdicom.base import SOPClass
+from highdicom.base_content import ContributingEquipment
 from highdicom.content import (
     ContentCreatorIdentificationCodeSequence,
     ModalityLUTTransformation,
@@ -93,6 +94,9 @@ class GrayscaleSoftcopyPresentationState(SOPClass):
             PresentationLUTTransformation
         ) = None,
         transfer_syntax_uid: str | UID = ExplicitVRLittleEndian,
+        contributing_equipment: Sequence[
+            ContributingEquipment
+        ] | None = None,
         **kwargs
     ):
         """
@@ -160,6 +164,9 @@ class GrayscaleSoftcopyPresentationState(SOPClass):
             polarity pixel values into device-independent presentation values
         transfer_syntax_uid: Union[str, highdicom.UID], optional
             Transfer syntax UID of the presentation state.
+        contributing_equipment: Sequence[highdicom.ContributingEquipment] | None, optional
+            Additional equipment that has contributed to the acquisition,
+            creation or modification of this instance.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -203,6 +210,7 @@ class GrayscaleSoftcopyPresentationState(SOPClass):
             device_serial_number=device_serial_number,
             institution_name=institution_name,
             institutional_department_name=institutional_department_name,
+            contributing_equipment=contributing_equipment,
             **kwargs
         )
         self.copy_patient_and_study_information(ref_im)

--- a/src/highdicom/pr/sop.py
+++ b/src/highdicom/pr/sop.py
@@ -210,11 +210,11 @@ class GrayscaleSoftcopyPresentationState(SOPClass):
             device_serial_number=device_serial_number,
             institution_name=institution_name,
             institutional_department_name=institutional_department_name,
-            contributing_equipment=contributing_equipment,
             **kwargs
         )
         self.copy_patient_and_study_information(ref_im)
         self.copy_specimen_information(ref_im)
+        self._add_contributing_equipment(contributing_equipment)
 
         # Presentation State Identification
         _add_presentation_state_identification_attributes(
@@ -371,6 +371,9 @@ class PseudoColorSoftcopyPresentationState(SOPClass):
         ) = None,
         icc_profile: bytes | None = None,
         transfer_syntax_uid: str | UID = ExplicitVRLittleEndian,
+        contributing_equipment: Sequence[
+            ContributingEquipment
+        ] | None = None,
         **kwargs
     ):
         """
@@ -440,6 +443,9 @@ class PseudoColorSoftcopyPresentationState(SOPClass):
             <part03/sect_C.11.15.html>`.
         transfer_syntax_uid: Union[str, highdicom.UID], optional
             Transfer syntax UID of the presentation state.
+        contributing_equipment: Sequence[highdicom.ContributingEquipment] | None, optional
+            Additional equipment that has contributed to the acquisition,
+            creation or modification of this instance.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -487,6 +493,7 @@ class PseudoColorSoftcopyPresentationState(SOPClass):
         )
         self.copy_patient_and_study_information(ref_im)
         self.copy_specimen_information(ref_im)
+        self._add_contributing_equipment(contributing_equipment)
 
         # Presentation State Identification
         _add_presentation_state_identification_attributes(
@@ -647,6 +654,9 @@ class ColorSoftcopyPresentationState(SOPClass):
         ) = None,
         icc_profile: bytes | None = None,
         transfer_syntax_uid: str | UID = ExplicitVRLittleEndian,
+        contributing_equipment: Sequence[
+            ContributingEquipment
+        ] | None = None,
         **kwargs
     ):
         """
@@ -706,6 +716,9 @@ class ColorSoftcopyPresentationState(SOPClass):
             <part03/sect_C.11.15.html>`.
         transfer_syntax_uid: Union[str, highdicom.UID], optional
             Transfer syntax UID of the presentation state.
+        contributing_equipment: Sequence[highdicom.ContributingEquipment] | None, optional
+            Additional equipment that has contributed to the acquisition,
+            creation or modification of this instance.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -753,6 +766,7 @@ class ColorSoftcopyPresentationState(SOPClass):
         )
         self.copy_patient_and_study_information(ref_im)
         self.copy_specimen_information(ref_im)
+        self._add_contributing_equipment(contributing_equipment)
 
         # Presentation State Identification
         _add_presentation_state_identification_attributes(
@@ -837,6 +851,9 @@ class AdvancedBlendingPresentationState(SOPClass):
         ) = None,
         icc_profile: bytes | None = None,
         transfer_syntax_uid: str | UID = ExplicitVRLittleEndian,
+        contributing_equipment: Sequence[
+            ContributingEquipment
+        ] | None = None,
         **kwargs
     ):
         """
@@ -904,6 +921,9 @@ class AdvancedBlendingPresentationState(SOPClass):
             :dcm:`C.11.15 <part03/sect_C.11.15.html>`.
         transfer_syntax_uid: Union[str, highdicom.UID], optional
             Transfer syntax UID of the presentation state.
+        contributing_equipment: Sequence[highdicom.ContributingEquipment] | None, optional
+            Additional equipment that has contributed to the acquisition,
+            creation or modification of this instance.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -952,6 +972,7 @@ class AdvancedBlendingPresentationState(SOPClass):
         )
         self.copy_patient_and_study_information(ref_im)
         self.copy_specimen_information(ref_im)
+        self._add_contributing_equipment(contributing_equipment)
 
         # Advanced Blending Presentation State
         blending_input_numbers = np.zeros(

--- a/src/highdicom/sc/sop.py
+++ b/src/highdicom/sc/sop.py
@@ -240,9 +240,9 @@ class SCImage(SOPClass):
             study_date=study_date,
             study_time=study_time,
             referring_physician_name=referring_physician_name,
-            contributing_equipment=contributing_equipment,
             **kwargs
         )
+        self._add_contributing_equipment(contributing_equipment)
 
         coordinate_system = CoordinateSystemNames(coordinate_system)
         if coordinate_system == CoordinateSystemNames.PATIENT:

--- a/src/highdicom/sc/sop.py
+++ b/src/highdicom/sc/sop.py
@@ -25,6 +25,7 @@ from pydicom.uid import (
 )
 
 from highdicom.base import SOPClass
+from highdicom.base_content import ContributingEquipment
 from highdicom.content import (
     IssuerOfIdentifier,
     SpecimenDescription,
@@ -99,6 +100,9 @@ class SCImage(SOPClass):
                 Sequence[SpecimenDescription]
             ) = None,
             transfer_syntax_uid: str = ExplicitVRLittleEndian,
+            contributing_equipment: Sequence[
+                ContributingEquipment
+            ] | None = None,
             **kwargs: Any
         ):
         """
@@ -188,6 +192,9 @@ class SCImage(SOPClass):
             (``"1.2.840.10008.1.2.4.50"``). Note that JPEG Baseline is a
             lossy compression method that will lead to a loss of detail in
             the image.
+        contributing_equipment: Sequence[highdicom.ContributingEquipment] | None, optional
+            Additional equipment that has contributed to the acquisition,
+            creation or modification of this instance.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -233,6 +240,7 @@ class SCImage(SOPClass):
             study_date=study_date,
             study_time=study_time,
             referring_physician_name=referring_physician_name,
+            contributing_equipment=contributing_equipment,
             **kwargs
         )
 
@@ -449,6 +457,9 @@ class SCImage(SOPClass):
             Sequence[SpecimenDescription]
         ) = None,
         transfer_syntax_uid: str = ImplicitVRLittleEndian,
+        contributing_equipment: Sequence[
+            ContributingEquipment
+        ] | None = None,
         **kwargs: Any
     ) -> Self:
         """Constructor that copies patient and study from an existing dataset.
@@ -519,6 +530,9 @@ class SCImage(SOPClass):
             data elements. The following lossless compressed transfer syntaxes
             are supported: RLE Lossless (``"1.2.840.10008.1.2.5"``), JPEG 2000
             Lossless (``"1.2.840.10008.1.2.4.90"``).
+        contributing_equipment: Sequence[highdicom.ContributingEquipment] | None, optional
+            Additional equipment that has contributed to the acquisition,
+            creation or modification of this instance.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -529,6 +543,22 @@ class SCImage(SOPClass):
             Secondary capture image.
 
         """  # noqa: E501
+        try:
+            acquisition_equipment = (
+                ContributingEquipment.for_image_acquisition(ref_dataset)
+            )
+        except Exception:
+            pass
+        else:
+            if contributing_equipment is None:
+                contributing_equipment = []
+            else:
+                contributing_equipment = list(contributing_equipment)
+            contributing_equipment = [
+                acquisition_equipment,
+                *list(contributing_equipment),
+            ]
+
         return cls(
             pixel_array=pixel_array,
             photometric_interpretation=photometric_interpretation,
@@ -561,5 +591,6 @@ class SCImage(SOPClass):
             issuer_of_container_identifier=issuer_of_container_identifier,
             specimen_descriptions=specimen_descriptions,
             transfer_syntax_uid=transfer_syntax_uid,
+            contributing_equipment=contributing_equipment,
             **kwargs
         )

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -541,22 +541,6 @@ class Segmentation(_Image):
                 f'Transfer syntax "{transfer_syntax_uid}" is not supported.'
             )
 
-        try:
-            acquisition_equipment = (
-                ContributingEquipment.for_image_acquisition(src_img)
-            )
-        except Exception:
-            pass
-        else:
-            if contributing_equipment is None:
-                contributing_equipment = []
-            else:
-                contributing_equipment = list(contributing_equipment)
-            contributing_equipment = [
-                acquisition_equipment,
-                *list(contributing_equipment),
-            ]
-
         segmentation_type = SegmentationTypeValues(segmentation_type)
         sop_class_uid = (
             '1.2.840.10008.5.1.4.1.1.66.7'
@@ -587,7 +571,6 @@ class Segmentation(_Image):
             manufacturer_model_name=manufacturer_model_name,
             device_serial_number=device_serial_number,
             software_versions=software_versions,
-            contributing_equipment=contributing_equipment,
             **kwargs
         )
 
@@ -1727,6 +1710,7 @@ class Segmentation(_Image):
 
         self.copy_specimen_information(src_img)
         self.copy_patient_and_study_information(src_img)
+        self._add_contributing_equipment(contributing_equipment, src_img)
 
         # Build lookup tables for efficient decoding
         self._build_luts()

--- a/src/highdicom/sr/sop.py
+++ b/src/highdicom/sr/sop.py
@@ -30,6 +30,7 @@ from pydicom.uid import (
 )
 
 from highdicom.base import SOPClass, _check_little_endian
+from highdicom.base_content import ContributingEquipment
 from highdicom.io import _wrapped_dcmread
 from highdicom.sr.coding import CodedConcept
 from highdicom.sr.enum import ValueTypeValues
@@ -74,6 +75,9 @@ class _SR(SOPClass):
         previous_versions: Sequence[Dataset] | None = None,
         record_evidence: bool = True,
         transfer_syntax_uid: str | UID = ExplicitVRLittleEndian,
+        contributing_equipment: Sequence[
+            ContributingEquipment
+        ] | None = None,
         **kwargs: Any
     ) -> None:
         """
@@ -135,6 +139,9 @@ class _SR(SOPClass):
         transfer_syntax_uid: str, optional
             UID of transfer syntax that should be used for encoding of
             data elements.
+        contributing_equipment: Sequence[highdicom.ContributingEquipment] | None, optional
+            Additional equipment that has contributed to the acquisition,
+            creation or modification of this instance.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -157,6 +164,22 @@ class _SR(SOPClass):
                 f'Transfer syntax "{transfer_syntax_uid}" is not supported.'
             )
 
+        try:
+            acquisition_equipment = (
+                ContributingEquipment.for_image_acquisition(evidence[0])
+            )
+        except Exception:
+            pass
+        else:
+            if contributing_equipment is None:
+                contributing_equipment = []
+            else:
+                contributing_equipment = list(contributing_equipment)
+            contributing_equipment = [
+                acquisition_equipment,
+                *list(contributing_equipment),
+            ]
+
         super().__init__(
             study_instance_uid=evidence[0].StudyInstanceUID,
             series_instance_uid=series_instance_uid,
@@ -178,6 +201,7 @@ class _SR(SOPClass):
             referring_physician_name=getattr(
                 evidence[0], 'ReferringPhysicianName', None
             ),
+            contributing_equipment=contributing_equipment,
             **kwargs
         )
 
@@ -491,6 +515,9 @@ class EnhancedSR(_SR):
         previous_versions: Sequence[Dataset] | None = None,
         record_evidence: bool = True,
         transfer_syntax_uid: str | UID = ExplicitVRLittleEndian,
+        contributing_equipment: Sequence[
+            ContributingEquipment
+        ] | None = None,
         **kwargs: Any
     ) -> None:
         """
@@ -547,6 +574,9 @@ class EnhancedSR(_SR):
             Whether provided `evidence` should be recorded (i.e. included
             in Pertinent Other Evidence Sequence) even if not referenced by
             content items in the document tree (default: ``True``)
+        contributing_equipment: Sequence[highdicom.ContributingEquipment] | None, optional
+            Additional equipment that has contributed to the acquisition,
+            creation or modification of this instance.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -577,6 +607,7 @@ class EnhancedSR(_SR):
             previous_versions=previous_versions,
             record_evidence=record_evidence,
             transfer_syntax_uid=transfer_syntax_uid,
+            contributing_equipment=contributing_equipment,
             **kwargs
         )
         unsupported_content = find_content_items(
@@ -622,6 +653,9 @@ class ComprehensiveSR(_SR):
         previous_versions: Sequence[Dataset] | None = None,
         record_evidence: bool = True,
         transfer_syntax_uid: str | UID = ExplicitVRLittleEndian,
+        contributing_equipment: Sequence[
+            ContributingEquipment
+        ] | None = None,
         **kwargs: Any
     ) -> None:
         """
@@ -681,6 +715,9 @@ class ComprehensiveSR(_SR):
         transfer_syntax_uid: str, optional
             UID of transfer syntax that should be used for encoding of
             data elements.
+        contributing_equipment: Sequence[highdicom.ContributingEquipment] | None, optional
+            Additional equipment that has contributed to the acquisition,
+            creation or modification of this instance.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -711,6 +748,7 @@ class ComprehensiveSR(_SR):
             previous_versions=previous_versions,
             record_evidence=record_evidence,
             transfer_syntax_uid=transfer_syntax_uid,
+            contributing_equipment=contributing_equipment,
             **kwargs
         )
         unsupported_content = find_content_items(
@@ -784,6 +822,9 @@ class Comprehensive3DSR(_SR):
         requested_procedures: Sequence[Dataset] | None = None,
         previous_versions: Sequence[Dataset] | None = None,
         record_evidence: bool = True,
+        contributing_equipment: Sequence[
+            ContributingEquipment
+        ] | None = None,
         **kwargs: Any
     ) -> None:
         """
@@ -843,6 +884,9 @@ class Comprehensive3DSR(_SR):
         transfer_syntax_uid: str, optional
             UID of transfer syntax that should be used for encoding of
             data elements.
+        contributing_equipment: Sequence[highdicom.ContributingEquipment] | None, optional
+            Additional equipment that has contributed to the acquisition,
+            creation or modification of this instance.
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -872,6 +916,7 @@ class Comprehensive3DSR(_SR):
             requested_procedures=requested_procedures,
             previous_versions=previous_versions,
             record_evidence=record_evidence,
+            contributing_equipment=contributing_equipment,
             **kwargs
         )
 

--- a/src/highdicom/sr/sop.py
+++ b/src/highdicom/sr/sop.py
@@ -164,22 +164,6 @@ class _SR(SOPClass):
                 f'Transfer syntax "{transfer_syntax_uid}" is not supported.'
             )
 
-        try:
-            acquisition_equipment = (
-                ContributingEquipment.for_image_acquisition(evidence[0])
-            )
-        except Exception:
-            pass
-        else:
-            if contributing_equipment is None:
-                contributing_equipment = []
-            else:
-                contributing_equipment = list(contributing_equipment)
-            contributing_equipment = [
-                acquisition_equipment,
-                *list(contributing_equipment),
-            ]
-
         super().__init__(
             study_instance_uid=evidence[0].StudyInstanceUID,
             series_instance_uid=series_instance_uid,
@@ -201,7 +185,6 @@ class _SR(SOPClass):
             referring_physician_name=getattr(
                 evidence[0], 'ReferringPhysicianName', None
             ),
-            contributing_equipment=contributing_equipment,
             **kwargs
         )
 
@@ -283,6 +266,7 @@ class _SR(SOPClass):
         self.ReferencedPerformedProcedureStepSequence: list[Dataset] = []
 
         self.copy_patient_and_study_information(evidence[0])
+        self._add_contributing_equipment(contributing_equipment, evidence[0])
 
     def _collect_predecessors(
         self,

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -44,7 +44,7 @@ from highdicom.sr.value_types import (
     DateTimeContentItem
 )
 
-from .utils import find_readable_images, write_and_read_dataset
+from .utils import write_and_read_dataset
 
 
 class TestContentCreatorIdentification(TestCase):

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -29,6 +29,7 @@ from highdicom import (
     PaletteColorLUT,
     PaletteColorLUTTransformation,
 )
+from highdicom.base_content import ContributingEquipment
 from highdicom.color import CIELabColor
 from highdicom.content import (
     AlgorithmIdentificationSequence,
@@ -1109,6 +1110,11 @@ class TestSegmentation:
         assert not hasattr(instance, 'PixelPaddingValue')
 
     def test_construction_2(self):
+        equipment = ContributingEquipment(
+            manufacturer='Other Manufacturer',
+            purpose_of_reference=codes.DCM.ProcessingEquipment,
+            device_serial_number='1.2.3.4'
+        )
         instance = Segmentation(
             [self._sm_image],
             self._sm_pixel_array,
@@ -1121,7 +1127,8 @@ class TestSegmentation:
             self._manufacturer,
             self._manufacturer_model_name,
             self._software_versions,
-            self._device_serial_number
+            self._device_serial_number,
+            contributing_equipment=[equipment],
         )
         assert instance.SOPClassUID == '1.2.840.10008.5.1.4.1.1.66.4'
         assert instance.PatientID == self._sm_image.PatientID
@@ -1188,6 +1195,12 @@ class TestSegmentation:
         assert not hasattr(instance, 'BluePaletteColorLookupTableDescriptor')
         assert not hasattr(instance, 'BluePaletteColorLookupTableData')
         assert not hasattr(instance, 'PixelPaddingValue')
+
+        equip_seq = instance.ContributingEquipmentSequence
+        assert len(equip_seq) == 3
+        assert equip_seq[0].Manufacturer == self._sm_image.Manufacturer
+        assert equip_seq[1].Manufacturer == 'Other Manufacturer'
+        assert equip_seq[2].ManufacturerModelName == 'highdicom'
 
     def test_construction_3(self):
         # Segmentation instance from a series of single-frame CT images


### PR DESCRIPTION
DICOM's Contributing Equipment Sequence is an optional general mechanism allows an object creator to list various pieces of equipment that have contributed to the creation of an instance. Currently highdicom does not populate this sequence in objects it creates. This PR adds support for the Contributing Equipment Sequence.

A new `ContributingEquipment` class encapsulates an item of the Contributing Equipment Sequence. All IODs now accept an argument to add items to this sequence. By default, highdicom will add an item for the initial image creation, and a further item for highdicom itself describing the instance creation.