### PR TITLE
Improvements to spatial calculations

### DIFF
--- a/docs/volume.rst
+++ b/docs/volume.rst
@@ -51,7 +51,8 @@ well as specifying the coordinate system being used.
     assert np.array_equal(vol.affine, affine)
 
     # The datatype of the array, its shape, and the spatial shape (not
-    # including any channels), may be accessed via properties
+    # including any channels, see below), may be accessed via
+    # properties
     print(vol.dtype)
     # uint8
 
@@ -215,7 +216,7 @@ volume.
         get_testdata_file('dicomdirtests/77654033/CT2/17166'),
     ]
     ct_series = [pydicom.dcmread(f) for f in ct_files]
-    
+
     vol = get_volume_from_series(ct_series)
 
 Array Manipulation
@@ -307,8 +308,9 @@ of the array:
   spatial shape.
 * :meth:`highdicom.Volume.flip_spatial()`, flips along certain axes.
 * :meth:`highdicom.Volume.match_geometry()`, given a second volume (or volume
-  geometry) manipulate the volume by permutations, flips, crops and/or pads to
-  match the geometry of the first volume to that of the second volume.
+  geometry) manipulate the volume by axis permutations, flips, crops and/or
+  pads (but no resampling) to match the geometry of the first volume to that of
+  the second volume.
 * :meth:`highdicom.Volume.pad()`, pads the array along spatial dimensions.
 * :meth:`highdicom.Volume.pad_to_spatial_shape()`, pad to a given spatial
   shape.
@@ -644,7 +646,8 @@ spatial metadata in the output object is correct.
     seg_dataset.save_as('segmentation.dcm')
 
     # Alternatively, it may be desirable to match the geometry of the output
-    # segmentation image to that of the input image
+    # segmentation image to that of the input image. This will "undo" the
+    # cropping and axis permutation operations done to the image volume above.
     seg_volume_matched = seg_volume.match_geometry(original_volume)
 
     # Use the segmentation volume as input to create a DICOM Segmentation

--- a/src/highdicom/image.py
+++ b/src/highdicom/image.py
@@ -2954,6 +2954,7 @@ class _Image(SOPClass):
         self,
         rtol: float | None = None,
         atol: float | None = None,
+        perpendicular_tol: float | None = None,
         allow_missing_positions: bool = False,
         allow_duplicate_positions: bool = True,
         filter: str | None = None,
@@ -2979,6 +2980,12 @@ class _Image(SOPClass):
             Absolute tolerance for determining spacing regularity. If slice
             spacings vary by less that this value (in mm), they are considered
             to be regular. Incompatible with ``rtol``.
+        perpendicular_tol: float | None, optional
+            Tolerance used to determine whether slices are stacked perpendicular to
+            their shared normal vector. The direction of stacking is considered
+            perpendicular if the dot product of its unit vector with the slice
+            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
+            default value of ``1e-3`` is used.
         allow_missing_positions: bool, optional
             Allow volume positions for which no frame exists in the image.
         allow_duplicate_positions: bool, optional
@@ -3058,6 +3065,7 @@ class _Image(SOPClass):
             spacing_hint=slice_spacing_hint,
             rtol=rtol,
             atol=atol,
+            perpendicular_tol=perpendicular_tol,
         )
         if volume_positions is None:
             raise RuntimeError(
@@ -3104,6 +3112,7 @@ class _Image(SOPClass):
         self,
         rtol: float | None = None,
         atol: float | None = None,
+        perpendicular_tol: float | None = None,
         allow_missing_positions: bool = False,
         filter: str | None = None,
         slice_start: int | None = None,
@@ -3125,6 +3134,12 @@ class _Image(SOPClass):
             Absolute tolerance for determining spacing regularity. If slice
             spacings vary by less that this value (in mm), they are considered
             to be regular. Incompatible with ``rtol``.
+        perpendicular_tol: float | None, optional
+            Tolerance used to determine whether slices are stacked perpendicular to
+            their shared normal vector. The direction of stacking is considered
+            perpendicular if the dot product of its unit vector with the slice
+            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
+            default value of ``1e-3`` is used.
         allow_missing_positions: bool, optional
             Allow volume positions for which no frame exists in the image.
         filter: str | None, optional
@@ -3164,6 +3179,7 @@ class _Image(SOPClass):
         geometry, frame_positions = self._get_stacked_volume_geometry(
             rtol=rtol,
             atol=atol,
+            perpendicular_tol=perpendicular_tol,
             allow_missing_positions=allow_missing_positions,
             filter=filter,
             slice_start=slice_start,
@@ -3189,6 +3205,7 @@ class _Image(SOPClass):
         *,
         rtol: float | None = None,
         atol: float | None = None,
+        perpendicular_tol: float | None = None,
         allow_missing_positions: bool = False,
         allow_duplicate_positions: bool = True,
     ) -> VolumeGeometry | None:
@@ -3215,6 +3232,12 @@ class _Image(SOPClass):
             Absolute tolerance for determining spacing regularity. If slice
             spacings vary by less that this value (in mm), they are considered
             to be regular. Incompatible with ``rtol``.
+        perpendicular_tol: float | None, optional
+            Tolerance used to determine whether slices are stacked perpendicular to
+            their shared normal vector. The direction of stacking is considered
+            perpendicular if the dot product of its unit vector with the slice
+            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
+            default value of ``1e-3`` is used.
         allow_missing_positions: bool, optional
             Allow volume positions for which no frame exists in the image.
         allow_duplicate_positions: bool, optional
@@ -3233,6 +3256,7 @@ class _Image(SOPClass):
             return self._get_volume_geometry(
                 atol=atol,
                 rtol=rtol,
+                perpendicular_tol=perpendicular_tol,
                 allow_missing_positions=allow_missing_positions,
                 allow_duplicate_positions=allow_duplicate_positions,
             )
@@ -3248,6 +3272,7 @@ class _Image(SOPClass):
         *,
         rtol: float | None = None,
         atol: float | None = None,
+        perpendicular_tol: float | None = None,
         allow_missing_positions: bool = False,
         allow_duplicate_positions: bool = True,
     ) -> VolumeGeometry:
@@ -3264,6 +3289,12 @@ class _Image(SOPClass):
             Absolute tolerance for determining spacing regularity. If slice
             spacings vary by less that this value (in mm), they are considered
             to be regular. Incompatible with ``rtol``.
+        perpendicular_tol: float | None, optional
+            Tolerance used to determine whether slices are stacked perpendicular to
+            their shared normal vector. The direction of stacking is considered
+            perpendicular if the dot product of its unit vector with the slice
+            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
+            default value of ``1e-3`` is used.
         allow_missing_positions: bool, optional
             Allow volume positions for which no frame exists in the image.
         allow_duplicate_positions: bool, optional
@@ -3326,6 +3357,7 @@ class _Image(SOPClass):
                 geometry, _ = self._get_stacked_volume_geometry(
                     rtol=rtol,
                     atol=atol,
+                    perpendicular_tol=perpendicular_tol,
                     allow_missing_positions=allow_missing_positions,
                     allow_duplicate_positions=allow_duplicate_positions,
                 )
@@ -4849,6 +4881,12 @@ class Image(_Image):
     """
 
     def __init__(self, *args, **kwargs):
+        """
+
+        Instances of this class should not be directly instantiated. Use the
+        from_dataset method or the imread function instead.
+
+        """
         raise RuntimeError(
             'Instances of this class should not be directly instantiated. Use '
             'the from_dataset method or the imread function instead.'
@@ -4877,6 +4915,7 @@ class Image(_Image):
         allow_missing_positions: bool = False,
         rtol: float | None = None,
         atol: float | None = None,
+        perpendicular_tol: float | None = None,
     ) -> Volume:
         """Create a :class:`highdicom.Volume` from the image.
 
@@ -5041,6 +5080,12 @@ class Image(_Image):
             Absolute tolerance for determining spacing regularity. If slice
             spacings vary by less that this value (in mm), they are considered
             to be regular. Incompatible with ``rtol``.
+        perpendicular_tol: float | None, optional
+            Tolerance used to determine whether slices are stacked perpendicular to
+            their shared normal vector. The direction of stacking is considered
+            perpendicular if the dot product of its unit vector with the slice
+            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
+            default value of ``1e-3`` is used.
 
         Returns
         -------
@@ -5156,6 +5201,7 @@ class Image(_Image):
             ) = self._prepare_volume_positions_table(
                 rtol=rtol,
                 atol=atol,
+                perpendicular_tol=perpendicular_tol,
                 allow_missing_positions=allow_missing_positions,
                 slice_start=slice_start,
                 slice_end=slice_end,
@@ -5445,6 +5491,7 @@ def get_volume_from_series(
     apply_icc_profile: bool | None = None,
     atol: float | None = None,
     rtol: float | None = None,
+    perpendicular_tol: float | None = None,
 ) -> Volume:
     """Create volume from a series of single frame images.
 
@@ -5553,6 +5600,12 @@ def get_volume_from_series(
         Absolute tolerance for determining spacing regularity. If slice
         spacings vary by less that this value (in mm), they
         are considered to be regular. Incompatible with ``rtol``.
+    perpendicular_tol: float | None, optional
+        Tolerance used to determine whether slices are stacked perpendicular to
+        their shared normal vector. The direction of stacking is considered
+        perpendicular if the dot product of its unit vector with the slice
+        normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
+        default value of ``1e-3`` is used.
 
     Returns
     -------
@@ -5607,6 +5660,7 @@ def get_volume_from_series(
             series_datasets,
             atol=atol,
             rtol=rtol,
+            perpendicular_tol=perpendicular_tol,
         )
         if slice_spacing is None:
             raise ValueError('Series is not a regularly-spaced volume.')

--- a/src/highdicom/image.py
+++ b/src/highdicom/image.py
@@ -2981,11 +2981,11 @@ class _Image(SOPClass):
             spacings vary by less that this value (in mm), they are considered
             to be regular. Incompatible with ``rtol``.
         perpendicular_tol: float | None, optional
-            Tolerance used to determine whether slices are stacked perpendicular to
-            their shared normal vector. The direction of stacking is considered
-            perpendicular if the dot product of its unit vector with the slice
-            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
-            default value of ``1e-3`` is used.
+            Tolerance used to determine whether slices are stacked
+            perpendicular to their shared normal vector. The direction of
+            stacking is considered perpendicular if the dot product of its unit
+            vector with the slice normal is within ``perpendicular_tol`` of
+            1.00. If ``None``, the default value of ``1e-3`` is used.
         allow_missing_positions: bool, optional
             Allow volume positions for which no frame exists in the image.
         allow_duplicate_positions: bool, optional
@@ -3135,11 +3135,11 @@ class _Image(SOPClass):
             spacings vary by less that this value (in mm), they are considered
             to be regular. Incompatible with ``rtol``.
         perpendicular_tol: float | None, optional
-            Tolerance used to determine whether slices are stacked perpendicular to
-            their shared normal vector. The direction of stacking is considered
-            perpendicular if the dot product of its unit vector with the slice
-            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
-            default value of ``1e-3`` is used.
+            Tolerance used to determine whether slices are stacked
+            perpendicular to their shared normal vector. The direction of
+            stacking is considered perpendicular if the dot product of its unit
+            vector with the slice normal is within ``perpendicular_tol`` of
+            1.00. If ``None``, the default value of ``1e-3`` is used.
         allow_missing_positions: bool, optional
             Allow volume positions for which no frame exists in the image.
         filter: str | None, optional
@@ -3233,11 +3233,11 @@ class _Image(SOPClass):
             spacings vary by less that this value (in mm), they are considered
             to be regular. Incompatible with ``rtol``.
         perpendicular_tol: float | None, optional
-            Tolerance used to determine whether slices are stacked perpendicular to
-            their shared normal vector. The direction of stacking is considered
-            perpendicular if the dot product of its unit vector with the slice
-            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
-            default value of ``1e-3`` is used.
+            Tolerance used to determine whether slices are stacked
+            perpendicular to their shared normal vector. The direction of
+            stacking is considered perpendicular if the dot product of its unit
+            vector with the slice normal is within ``perpendicular_tol`` of
+            1.00. If ``None``, the default value of ``1e-3`` is used.
         allow_missing_positions: bool, optional
             Allow volume positions for which no frame exists in the image.
         allow_duplicate_positions: bool, optional
@@ -3290,11 +3290,11 @@ class _Image(SOPClass):
             spacings vary by less that this value (in mm), they are considered
             to be regular. Incompatible with ``rtol``.
         perpendicular_tol: float | None, optional
-            Tolerance used to determine whether slices are stacked perpendicular to
-            their shared normal vector. The direction of stacking is considered
-            perpendicular if the dot product of its unit vector with the slice
-            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
-            default value of ``1e-3`` is used.
+            Tolerance used to determine whether slices are stacked
+            perpendicular to their shared normal vector. The direction of
+            stacking is considered perpendicular if the dot product of its unit
+            vector with the slice normal is within ``perpendicular_tol`` of
+            1.00. If ``None``, the default value of ``1e-3`` is used.
         allow_missing_positions: bool, optional
             Allow volume positions for which no frame exists in the image.
         allow_duplicate_positions: bool, optional

--- a/src/highdicom/image.py
+++ b/src/highdicom/image.py
@@ -2563,6 +2563,7 @@ class _Image(SOPClass):
             return None
 
         if len(vals) != 1:
+            logger.info(f"Frames do not have a consistent {kw}.")
             raise RuntimeError(
                 f'Frames do not have a consistent {kw}.'
             )
@@ -3235,7 +3236,11 @@ class _Image(SOPClass):
                 allow_missing_positions=allow_missing_positions,
                 allow_duplicate_positions=allow_duplicate_positions,
             )
-        except RuntimeError:
+        except RuntimeError as e:
+            logger.info(
+                "Image is not a volume due to the following error. Earlier "
+                f"log messages may contain more information:\n {e}."
+            )
             return None
 
     def _get_volume_geometry(
@@ -3273,6 +3278,9 @@ class _Image(SOPClass):
 
         """
         if self._coordinate_system is None:
+            logger.info(
+                "Image is not a volume because it has no FrameOfReferenceUID."
+            )
             raise RuntimeError(
                 "Image does not exist within a frame-of-reference "
                 "coordinate system."
@@ -3322,6 +3330,11 @@ class _Image(SOPClass):
                     allow_duplicate_positions=allow_duplicate_positions,
                 )
                 return geometry
+            else:
+                logger.info(
+                    "Image is not a volume because it exists in the slide "
+                    "coordinate system but is not tiled."
+                )
         else:
             # Single frame image, only supports patient coordinate system
             # currently
@@ -3345,6 +3358,11 @@ class _Image(SOPClass):
                         1.0
                     ),
                     coordinate_system=self._coordinate_system,
+                )
+            else:
+                logger.info(
+                    "Image is not a volume because it does not contain image "
+                    "position information."
                 )
 
         raise RuntimeError(

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -4239,6 +4239,7 @@ class Segmentation(_Image):
         *,
         rtol: float | None = None,
         atol: float | None = None,
+        perpendicular_tol: float | None = None,
         allow_missing_positions: bool = True,
         allow_duplicate_positions: bool = True,
     ) -> VolumeGeometry | None:
@@ -4261,6 +4262,12 @@ class Segmentation(_Image):
             Absolute tolerance for determining spacing regularity. If slice
             spacings vary by less that this value (in mm), they are considered
             to be regular. Incompatible with ``rtol``.
+        perpendicular_tol: float | None, optional
+            Tolerance used to determine whether slices are stacked perpendicular to
+            their shared normal vector. The direction of stacking is considered
+            perpendicular if the dot product of its unit vector with the slice
+            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
+            default value of ``1e-3`` is used.
         allow_missing_positions: bool, optional
             Allow volume positions for which no frame exists in the image.
         allow_duplicate_positions: bool, optional
@@ -4278,6 +4285,7 @@ class Segmentation(_Image):
         return super().get_volume_geometry(
             rtol=rtol,
             atol=atol,
+            perpendicular_tol=perpendicular_tol,
             allow_missing_positions=allow_missing_positions,
             allow_duplicate_positions=allow_duplicate_positions,
         )
@@ -4303,6 +4311,7 @@ class Segmentation(_Image):
         allow_missing_positions: bool = True,
         rtol: float | None = None,
         atol: float | None = None,
+        perpendicular_tol: float | None = None,
     ) -> Volume:
         """Create a :class:`highdicom.Volume` from the segmentation.
 
@@ -4415,6 +4424,12 @@ class Segmentation(_Image):
             Absolute tolerance for determining spacing regularity. If slice
             spacings vary by less that this value (in mm), they
             are considered to be regular. Incompatible with ``rtol``.
+        perpendicular_tol: float | None, optional
+            Tolerance used to determine whether slices are stacked perpendicular to
+            their shared normal vector. The direction of stacking is considered
+            perpendicular if the dot product of its unit vector with the slice
+            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
+            default value of ``1e-3`` is used.
 
         """
         # Checks on validity of the inputs
@@ -4514,6 +4529,7 @@ class Segmentation(_Image):
             ) = self._prepare_volume_positions_table(
                 rtol=rtol,
                 atol=atol,
+                perpendicular_tol=perpendicular_tol,
                 allow_missing_positions=allow_missing_positions,
                 slice_start=slice_start,
                 slice_end=slice_end,

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -4263,11 +4263,11 @@ class Segmentation(_Image):
             spacings vary by less that this value (in mm), they are considered
             to be regular. Incompatible with ``rtol``.
         perpendicular_tol: float | None, optional
-            Tolerance used to determine whether slices are stacked perpendicular to
-            their shared normal vector. The direction of stacking is considered
-            perpendicular if the dot product of its unit vector with the slice
-            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
-            default value of ``1e-3`` is used.
+            Tolerance used to determine whether slices are stacked
+            perpendicular to their shared normal vector. The direction of
+            stacking is considered perpendicular if the dot product of its unit
+            vector with the slice normal is within ``perpendicular_tol`` of
+            1.00. If ``None``, the default value of ``1e-3`` is used.
         allow_missing_positions: bool, optional
             Allow volume positions for which no frame exists in the image.
         allow_duplicate_positions: bool, optional
@@ -4425,11 +4425,11 @@ class Segmentation(_Image):
             spacings vary by less that this value (in mm), they
             are considered to be regular. Incompatible with ``rtol``.
         perpendicular_tol: float | None, optional
-            Tolerance used to determine whether slices are stacked perpendicular to
-            their shared normal vector. The direction of stacking is considered
-            perpendicular if the dot product of its unit vector with the slice
-            normal is within ``perpendicular_tol`` of 1.00. If ``None``, the
-            default value of ``1e-3`` is used.
+            Tolerance used to determine whether slices are stacked
+            perpendicular to their shared normal vector. The direction of
+            stacking is considered perpendicular if the dot product of its unit
+            vector with the slice normal is within ``perpendicular_tol`` of
+            1.00. If ``None``, the default value of ``1e-3`` is used.
 
         """
         # Checks on validity of the inputs

--- a/src/highdicom/spatial.py
+++ b/src/highdicom/spatial.py
@@ -3611,12 +3611,14 @@ def get_volume_positions(
         if not is_regular:
             max_deviation = float(
                 np.abs(
-                    origin_distance_multiples - origin_distance_multiples.round()
+                    origin_distance_multiples -
+                    origin_distance_multiples.round()
                 ).max()
             )
             logger.info("Frame positions are not regularly spaced.")
             logger.debug(
-                f"Maximum spacing deviation from regular: {max_deviation:.2e} mm."
+                f"Maximum spacing deviation from regular: {max_deviation:.2e} "
+                "mm."
             )
 
         inverse_sort_index = origin_distance_multiples.round().astype(np.int64)

--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -1653,8 +1653,8 @@ class _VolumeBase(ABC):
     ) -> Self:
         """Match the geometry of this volume to another.
 
-        This performs a combination of permuting, padding and cropping, and
-        flipping (in that order) such that the geometry of this volume matches
+        This performs a combination of permuting axes, flipping, padding, and
+        cropping (in that order) such that the geometry of this volume matches
         that of ``other``. Notably, the voxels are not resampled. If the
         geometry cannot be matched using these operations, then a
         ``RuntimeError`` is raised.
@@ -1663,6 +1663,20 @@ class _VolumeBase(ABC):
         ----------
         other: Union[highdicom.Volume, highdicom.VolumeGeometry]
             Volume or volume geometry to which this volume should be matched.
+        mode: Union[highdicom.PadModes, str], optional
+            Mode to use to pad the array. See :class:`highdicom.PadModes` for
+            options.
+        constant_value: Union[float, Sequence[float]], optional
+            Value used to pad when mode is ``"CONSTANT"``. With other pad
+            modes, this argument is ignored.
+        per_channel: bool, optional
+            For padding modes that involve calculation of image statistics to
+            determine the padding value (i.e. ``MINIMUM``, ``MAXIMUM``,
+            ``MEAN``, ``MEDIAN``), pad each channel separately using the value
+            calculated using that channel alone (rather than the statistics of
+            the entire array). For other padding modes, this argument makes no
+            difference. This should be True only if the volume has a channel
+            dimension.
 
         Returns
         -------
@@ -3268,8 +3282,8 @@ class Volume(_VolumeBase):
             ``MEAN``, ``MEDIAN``), pad each channel separately using the value
             calculated using that channel alone (rather than the statistics of
             the entire array). For other padding modes, this argument makes no
-            difference. This should not the True if the image does not have a
-            channel dimension.
+            difference. This should be True only if the volume has a channel
+            dimension.
 
         Returns
         -------

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -961,7 +961,7 @@ def test_get_series_slice_spacing_regular():
     assert spacing == 1.25
 
 
-def test_get_spacing_duplicates():
+def test_get_volume_positions_duplicates():
     # Test ability to determine spacing and volume positions with duplicate
     # positions
     position_indices = np.array(
@@ -990,7 +990,7 @@ def test_get_spacing_duplicates():
     assert volume_positions == position_indices.tolist()
 
 
-def test_get_spacing_missing():
+def test_get_volume_positions_missing():
     # Test ability to determine spacing and volume positions with missing
     # slices
     position_indices = np.array(
@@ -1020,7 +1020,7 @@ def test_get_spacing_missing():
     assert volume_positions is None
 
 
-def test_get_spacing_missing_duplicates():
+def test_get_volume_positions_missing_duplicates():
     # Test ability to determine spacing and volume positions with missing
     # slices and duplicate positions
     position_indices = np.array(
@@ -1058,7 +1058,7 @@ def test_get_spacing_missing_duplicates():
     assert volume_positions == position_indices.tolist()
 
 
-def test_get_spacing_missing_duplicates_non_consecutive():
+def test_get_volume_positions_missing_duplicates_non_consecutive():
     # Test ability to determine spacing and volume positions with missing
     # slices and duplicate positions, with no two positions from consecutive
     # slices
@@ -1091,7 +1091,7 @@ def test_get_spacing_missing_duplicates_non_consecutive():
     assert volume_positions == position_indices.tolist()
 
 
-def test_get_spacing_coplanar():
+def test_get_volume_positions_coplanar():
     # Check that coplanar points are not considered a volume
     positions = [
         [0.0, 0.0, 10.0],
@@ -1113,6 +1113,55 @@ def test_get_spacing_coplanar():
             )
             assert spacing is None
             assert volume_positions is None
+
+
+def test_get_volume_positions_non_perpendicular():
+    # Check that slices stacked along a vector that is not perpendicular to
+    # their normals (a "staircase") are not considered a volume
+    positions = [
+        [0.0, 0.0, 10.0],
+        [0.1, 0.0, 11.0],
+        [0.2, 0.0, 12.0],
+    ]
+    orientation = [1, 0, 0, 0, -1, 0]
+
+    # Regardless of values of allow_missing_positions and
+    # allow_duplicate_positions, this is not a volume
+    for allow_duplicate_positions in [False, True]:
+        for allow_missing_positions in [False, True]:
+            spacing, volume_positions = get_volume_positions(
+                positions,
+                orientation,
+                allow_missing_positions=allow_missing_positions,
+                allow_duplicate_positions=allow_duplicate_positions,
+            )
+            assert spacing is None
+            assert volume_positions is None
+
+
+def test_get_volume_positions_non_perpendicular_higher_tol():
+    # Repeat above test with a higher tolerance so that the slices are
+    # considered a volume
+    positions = [
+        [0.0, 0.0, 10.0],
+        [0.1, 0.0, 11.0],
+        [0.2, 0.0, 12.0],
+    ]
+    orientation = [1, 0, 0, 0, -1, 0]
+
+    # Regardless of values of allow_missing_positions and
+    # allow_duplicate_positions, this is not a volume
+    for allow_duplicate_positions in [False, True]:
+        for allow_missing_positions in [False, True]:
+            spacing, volume_positions = get_volume_positions(
+                positions,
+                orientation,
+                allow_missing_positions=allow_missing_positions,
+                allow_duplicate_positions=allow_duplicate_positions,
+                perpendicular_tol=1e-2,  # higher tolerance
+            )
+            assert spacing is not None
+            assert volume_positions is not None
 
 
 def test_transform_affine_matrix():


### PR DESCRIPTION
A couple of related improvements to the way highdicom does spatial calculations. The general goal is to make it easier to understand and remedy situations where highdicom does not recognise an image as a volume (but the user expects that it should):

- For calculations that are used to determine whether an image is a volume, add debug logging calls containing information that would allow a user to determine which of the various conditions are not met (orientation, spacing, handedness, perpendicularity)
- Add an explicit `perpendicular_tol` parameter used to determine whether the direction of frame stacking is along the normal as of a given frame (i.e. perpendicular to the in-frame direction). Previously this was just a hard-coded tolerance value.
- A few improvements to related documentation 