### PR TITLE
Add further description of VOLUME pixel origin interpretation

### DIFF
--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -868,8 +868,11 @@ class ImageRegion(ScoordContentItem):
             (``highdicom.sr.PixelOriginInterpretationValues.VOLUME``) or
             relative to an individual frame
             (``highdicom.sr.PixelOriginInterpretationValues.FRAME``)
-            of the source image
-            (default: ``highdicom.sr.PixelOriginInterpretationValues.VOLUME``)
+            of the source image. This distinction is only meaningful when the
+            referenced image is a tiled image. In other situations, this should
+            be left unspecified. The default behavior is to use ``VOLUME`` if
+            the source image is a VL Whole Slice Microscopy Image, and
+            otherwise leave the value unspecified.
 
         """  # noqa: E501
         graphic_type = GraphicTypeValues(graphic_type)

--- a/src/highdicom/sr/enum.py
+++ b/src/highdicom/sr/enum.py
@@ -253,4 +253,11 @@ class PixelOriginInterpretationValues(Enum):
     """Relative to the individual frame."""
 
     VOLUME = 'VOLUME'
-    """Relative to the Total Pixel Matrix of the VOLUME image."""
+    """Relative to the Total Pixel Matrix of the VOLUME image.
+
+    Note that this is only appropriate if the source image is a tiled pathology
+    image with ``'VOLUME'`` as the third value of Image Type . ``'FRAME'``
+    should be used in all other situations, including all radiology and other
+    non-pathology images.
+
+    """

--- a/src/highdicom/sr/enum.py
+++ b/src/highdicom/sr/enum.py
@@ -256,7 +256,7 @@ class PixelOriginInterpretationValues(Enum):
     """Relative to the Total Pixel Matrix of the VOLUME image.
 
     Note that this is only appropriate if the source image is a tiled pathology
-    image with ``'VOLUME'`` as the third value of Image Type . ``'FRAME'``
+    image with ``'VOLUME'`` as the third value of Image Type. ``'FRAME'``
     should be used in all other situations, including all radiology and other
     non-pathology images.
 

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -1563,7 +1563,8 @@ class ScoordContentItem(ContentItem):
         graphic_data: np.ndarray,
         pixel_origin_interpretation: (
             str |
-            PixelOriginInterpretationValues
+            PixelOriginInterpretationValues |
+            None
         ) = None,
         fiducial_uid: str | UID | None = None,
         relationship_type: str | RelationshipTypeValues | None = None
@@ -1583,7 +1584,9 @@ class ScoordContentItem(ContentItem):
             relative to the total pixel matrix
             (``highdicom.sr.PixelOriginInterpretationValues.VOLUME``) or
             relative to an individual frame
-            (``highdicom.sr.PixelOriginInterpretationValues.FRAME``)
+            (``highdicom.sr.PixelOriginInterpretationValues.FRAME``). This
+            distinction is only meaningful when the referenced image is a tiled
+            image. In other situations, this should be left unspecified.
         fiducial_uid: Union[highdicom.UID, str, None], optional
             Unique identifier for the content item
         relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional


### PR DESCRIPTION
Clarify when VOLUME is appropriate as the pixel origin interpretation, following questions on this from @deepakri201 

TODO: enforce the constraint that VOLUME can only be used for tiled images. This would require searching the content tree for Image Region content items and comparing it to the provided evidence in the constructor of the SR