### PR TITLE
Fix parsing TID1500 when template identifiers are missing

### DIFF
--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -5010,7 +5010,10 @@ class TestGetPlanarMeasurementGroups:
         assert ins_uid == self._ref_seg.SOPInstanceUID
         assert class_uid == self._ref_seg.SOPClassUID
 
-    def test_get_groups_invalid_reference_types(self, content: MeasurementReport):
+    def test_get_groups_invalid_reference_types(
+        self,
+        content: MeasurementReport
+    ):
         with pytest.raises(ValueError):
             # ReferencedSegment is invalid for planar groups
             content.get_planar_roi_measurement_groups(
@@ -5606,10 +5609,14 @@ class TestGetVolumetricMeasurementGroups:
 
         # Without template IDs, the single group is returned as planar
         assert len(
-            sr_read_no_template_ids.content.get_planar_roi_measurement_groups()
+            sr_read_no_template_ids
+            .content
+            .get_planar_roi_measurement_groups()
         ) == 1
         assert len(
-            sr_read_no_template_ids.content.get_volumetric_roi_measurement_groups()
+            sr_read_no_template_ids
+            .content
+            .get_volumetric_roi_measurement_groups()
         ) == 0
 
 


### PR DESCRIPTION
- Resolves #352 
- Repeats tests for TID1500 parsing without template identifiers
- This identified a further issue. A measurement group with a single SCOORD image region and no template identifier could satisfy either TID1410 or TID1411, and as such cannot be distinguished without the template identifier. Now, such groups are considered TID1410 (Planar ROI Measurements and Qualitative Evaluations) by highdicom
