### PR TITLE
Fix tiled segmentation volume origin bug

### DIFF
--- a/docs/volume.rst
+++ b/docs/volume.rst
@@ -756,7 +756,7 @@ Creating a volume from an ITK Image:
     im = itk.image(...)
 
     # Reverse array dimension order
-    array = np.transpose(itk.array_from_image(im), [2, 1, 0])
+    array = itk.array_from_image(im).transpose([2, 1, 0])
 
     vol2 = hd.Volume.from_components(
         array=array,
@@ -771,14 +771,13 @@ Creating an ITK Image from a Volume:
 .. code-block:: python
 
     import itk
-    import numpy as np
     import highdicom as hd
 
 
     vol = hd.Volume(...)
 
     # Reverse array dimension order
-    array = np.transpose(vol.array, [2, 1, 0])
+    array = vol.array.transpose([2, 1, 0])
 
     im = itk.image_from_array(array)
     im.SetOrigin(vol.position)

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -3847,8 +3847,8 @@ class Segmentation(_Image):
 
             affine = volume_geometry[
                 :,
-                row_start - 1:,
-                column_start - 1:,
+                row_start:,
+                column_start:,
             ].affine
         else:
             # Check that the combination of frame numbers and segment numbers

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -5131,6 +5131,24 @@ class TestSegmentationParsing:
         tpm2 = seg_no_dim_ind.get_total_pixel_matrix()
         assert np.array_equal(tpm1, tpm2)
 
+    def test_tiled_full_volume(self):
+        # Check that a tiled segmentation is read with the correct affine
+        file_path = Path(__file__)
+        data_dir = file_path.parent.parent.joinpath('data')
+        f = data_dir / 'test_files/seg_image_sm_dots_tiled_full.dcm'
+        seg = segread(f)
+        origin_seq = seg.TotalPixelMatrixOriginSequence[0]
+
+        expected = np.array(
+            [
+                origin_seq.XOffsetInSlideCoordinateSystem,
+                origin_seq.YOffsetInSlideCoordinateSystem,
+                0.0
+            ]
+        )
+        vol = seg.get_volume()
+        assert np.array_equal(vol.position, expected)
+
     def test_shared_referenced_segment(self):
         # Test parsing when the referenced segment is in the shared functional
         # groups


### PR DESCRIPTION
Fix error producing incorrect origins when using get_volume on a tiled segmentation due to incorrect indexing