### PR TITLE
Further date control

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 import pytest
 import unittest
@@ -59,6 +60,92 @@ class TestBase(unittest.TestCase):
         )
         assert instance.SoftwareVersions is not None
         assert instance.ManufacturerModelName is not None
+        assert hasattr(instance, 'ContentDate')
+        assert hasattr(instance, 'ContentTime')
+        assert not hasattr(instance, 'SeriesDate')
+        assert not hasattr(instance, 'SeriesTime')
+
+    def test_content_time_without_date(self):
+        msg = (
+            "'content_time' may not be specified without "
+            "'content_date'."
+        )
+        with pytest.raises(TypeError, match=msg):
+            SOPClass(
+                study_instance_uid=UID(),
+                series_instance_uid=UID(),
+                series_number=1,
+                sop_instance_uid=UID(),
+                sop_class_uid='1.2.840.10008.5.1.4.1.1.88.33',
+                instance_number=1,
+                modality='SR',
+                manufacturer='highdicom',
+                manufacturer_model_name='foo-bar',
+                software_versions='v1.0.0',
+                transfer_syntax_uid=ExplicitVRLittleEndian,
+                content_time=datetime.time(12, 34, 56),
+            )
+
+    def test_series_datetime(self):
+        instance = SOPClass(
+            study_instance_uid=UID(),
+            series_instance_uid=UID(),
+            series_number=1,
+            sop_instance_uid=UID(),
+            sop_class_uid='1.2.840.10008.5.1.4.1.1.88.33',
+            instance_number=1,
+            modality='SR',
+            manufacturer='highdicom',
+            manufacturer_model_name='foo-bar',
+            software_versions='v1.0.0',
+            transfer_syntax_uid=ExplicitVRLittleEndian,
+            series_date=datetime.date(2000, 12, 1),
+            series_time=datetime.time(12, 34, 56),
+        )
+        assert hasattr(instance, 'SeriesDate')
+        assert hasattr(instance, 'SeriesTime')
+
+    def test_series_date_without_time(self):
+        msg = (
+            "'series_time' may not be specified without "
+            "'series_date'."
+        )
+        with pytest.raises(TypeError, match=msg):
+            SOPClass(
+                study_instance_uid=UID(),
+                series_instance_uid=UID(),
+                series_number=1,
+                sop_instance_uid=UID(),
+                sop_class_uid='1.2.840.10008.5.1.4.1.1.88.33',
+                instance_number=1,
+                modality='SR',
+                manufacturer='highdicom',
+                manufacturer_model_name='foo-bar',
+                software_versions='v1.0.0',
+                transfer_syntax_uid=ExplicitVRLittleEndian,
+                series_time=datetime.time(12, 34, 56),
+            )
+
+    def test_series_date_after_content(self):
+        msg = (
+            "'series_date' must not be later than 'content_date'."
+        )
+        with pytest.raises(ValueError, match=msg):
+            SOPClass(
+                study_instance_uid=UID(),
+                series_instance_uid=UID(),
+                series_number=1,
+                sop_instance_uid=UID(),
+                sop_class_uid='1.2.840.10008.5.1.4.1.1.88.33',
+                instance_number=1,
+                modality='SR',
+                manufacturer='highdicom',
+                manufacturer_model_name='foo-bar',
+                software_versions='v1.0.0',
+                transfer_syntax_uid=ExplicitVRLittleEndian,
+                content_date=datetime.date(2000, 12, 1),
+                series_date=datetime.date(2000, 12, 2),
+            )
 
     def test_big_endian(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Addressed #375:

- InstanceCreationDate and InstanceCreationTime are automatically added to all instances generated
- ContentDate and ContentTime can now be overridden by the user, otherwise will default to the current time
- SeriesDate and SeriesTime can be specified, but I decided not to use a default value. This is because if a user creates a series of images manually and does not specify the SeriesDate, highdicom has no way to ensure that the values are consistent within a series, and being inconsistent would be an error

@DanielaSchacherer @fedorov @dclunie 