### PR TITLE
Add support for python 3.14

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -15,7 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        # NB no 3.12 because an issue with coverage makes it extremely slow
+        # and the likelihood of 3.12-specific bugs is considered low at this
+        # stage
+        python-version: ["3.10", "3.11", "3.13", "3.14"]
         dependencies: [".", "'.[libjpeg]'"]
 
     env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Multimedia :: Graphics",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]


### PR DESCRIPTION
Add support for python 3.14 in the `pyproject.toml` classifiers and through tests with 3.14 on github actions

Also remove 3.12 from github actions. There is some incompatibility with coverage that makes these tests painfully slow and https://github.com/ImagingDataCommons/highdicom/pull/340 has not sufficiently addressed it. This does not mean support for 3.12 is dropped, just that it is not specifically tested