### PR TITLE
Avoid division by zero in volume normalization

### DIFF
--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1072,6 +1072,29 @@ def test_normalize():
     assert np.isclose(normed.array.max(), 1.0)
 
 
+def test_normalize_uniform():
+    # Normaliztion when std is zero
+    arr = np.ones((10, 10, 10))
+    vol = Volume(
+        arr,
+        np.eye(4),
+        coordinate_system="PATIENT",
+    )
+
+    normed = vol.normalize_mean_std()
+    assert np.array_equal(normed.array, np.zeros_like(arr))
+
+    arr = np.ones((10, 10, 10))
+    vol = Volume(
+        arr,
+        np.eye(4),
+        coordinate_system="PATIENT",
+    )
+
+    normed = vol.normalize_min_max()
+    assert np.array_equal(normed.array, np.zeros_like(arr))
+
+
 @pytest.mark.parametrize(
     'kw,pytype',
     [


### PR DESCRIPTION
If a volume contains a single unique value, currently the normalization methods will give rise to a divide by zero error.

This PR removes scaling when a single unique value is found in an array, in order to avoid the divide by zero error