### PR TITLE
Increase tolerance used to determine a matrix is orthogonal

### DIFF
--- a/src/highdicom/spatial.py
+++ b/src/highdicom/spatial.py
@@ -29,7 +29,7 @@ _DEFAULT_PERPENDICULAR_TOLERANCE = 1e-3
 
 
 _DEFAULT_ORTHOGONAL_TOLERANCE = 1e-4
-"""Default tolerance on the matrix elements to determin orthogonality."""
+"""Default tolerance on the matrix elements to determine orthogonality."""
 
 
 PATIENT_ORIENTATION_OPPOSITES = {


### PR DESCRIPTION
I have found a number of files where the default tolerance of `1e-5` is too tight. Increasing to `1e-4` to increase usability