### PR TITLE
Remove packaging version specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pydicom>=3.0.1",
     "pyjpegls>=1.0.0",
     "typing-extensions>=4.0.0",
-    "packaging>=25.0"
+    "packaging"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pydicom>=3.0.1",
     "pyjpegls>=1.0.0",
     "typing-extensions>=4.0.0",
-    "packaging"
+    "packaging>=17.1"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The packaging version specifier is currently quite a recent version, meaning that it could be quite restrictive on the compatibility of highdicom with other packages. This is likely unnecessary because we use only very basic functionality from `packaging`, and could be rather frustrating (e.g. I already found it makes highdicom incompatible with a somewhat recent `mlflow` version).

I propose we remove the version specifier, unless you have a more specific suggestion. What do you think @mccle?