### PR TITLE
Volume dtype restriction

### DIFF
--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -2871,8 +2871,8 @@ class Volume(_VolumeBase):
             [np.floating, np.integer, np.bool_]
         ]):
             raise ValueError(
-                "Array must have a dtype of float, integer,"
-                f" or bool, received '{value.dtype}'."
+                "Argument 'array' must have an integer, floating point, "
+                f" or boolean dtype, received '{array.dtype}'."
             )
 
         self._array = value

--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -2504,6 +2504,15 @@ class Volume(_VolumeBase):
                 "Argument 'array' must be at least three dimensional."
             )
 
+        if not any([
+            np.issubdtype(array.dtype, dtype) for dtype in
+            [np.floating, np.integer, np.bool_]
+        ]):
+            raise ValueError(
+                "Argument 'array' must have a dtype of float, integer,"
+                f" or bool, received '{array.dtype}'."
+            )
+
         if channels is None:
             channels = {}
 
@@ -2856,6 +2865,16 @@ class Volume(_VolumeBase):
             raise ValueError(
                 "Array must match the shape of the existing array."
             )
+
+        if not any([
+            np.issubdtype(value.dtype, dtype) for dtype in
+            [np.floating, np.integer, np.bool_]
+        ]):
+            raise ValueError(
+                "Array must have a dtype of float, integer,"
+                f" or bool, received '{value.dtype}'."
+            )
+
         self._array = value
 
     def astype(self, dtype: type) -> Self:

--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -2509,8 +2509,8 @@ class Volume(_VolumeBase):
             [np.floating, np.integer, np.bool_]
         ]):
             raise ValueError(
-                "Argument 'array' must have a dtype of float, integer,"
-                f" or bool, received '{array.dtype}'."
+                "Array must have an integer, floating point,"
+                f" or boolean dtype, received '{array.dtype}'."
             )
 
         if channels is None:
@@ -2871,7 +2871,7 @@ class Volume(_VolumeBase):
             [np.floating, np.integer, np.bool_]
         ]):
             raise ValueError(
-                "Array must have an integer, floating point, "
+                "Array must have an integer, floating point,"
                 f" or boolean dtype, received '{value.dtype}'."
             )
 

--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -3608,7 +3608,7 @@ class Volume(_VolumeBase):
         """Convert the Volume to ``SimpleITK.Image`` format.
 
         This method requires an optional dependency to be installed
-        separately from highdicom, specifically ``SimpleITK>=2.2.1``.
+        separately from highdicom, specifically ``SimpleITK``.
 
         The Volume is converted to a 3D ``SimpleITK.Image``. If
         its array's current datatype is not supported by SimpleITK,
@@ -3697,7 +3697,7 @@ class Volume(_VolumeBase):
         """Construct a Volume from a `SimpleITK.Image`.
 
         This method requires an optional dependency to be installed
-        separately from highdicom, specifically ``SimpleITK>=2.2.1``.
+        separately from highdicom, specifically ``SimpleITK``.
 
         The ``SimpleITK.Image`` is converted to a 3D Volume.
         Spatial metadata (spacing, direction, origin) is preserved
@@ -3756,7 +3756,7 @@ class Volume(_VolumeBase):
         """Convert the volume to `itk.Image` format.
 
         This method requires an optional dependency to be installed
-        separately from highdicom, specifically ``itk>=5.4.0``.
+        separately from highdicom, specifically ``itk``.
 
         The Volume is converted to a 3D ``itk.image``. If its array's
         current datatype is not supported by ITK, it is safely cast to
@@ -3869,7 +3869,7 @@ class Volume(_VolumeBase):
         """Construct a Volume from an `itk.Image`.
 
         This method requires an optional dependency to be installed
-        separately from highdicom, specifically ``itk>=5.4.0``.
+        separately from highdicom, specifically ``itk``.
 
         The ``itk.Image`` is converted to a 3D Volume.
         Spatial metadata (spacing, direction, origin) is preserved

--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -3607,6 +3607,9 @@ class Volume(_VolumeBase):
     def to_sitk(self) -> 'SimpleITK.Image':  # noqa: F821
         """Convert the Volume to ``SimpleITK.Image`` format.
 
+        This method requires an optional dependency to be installed
+        separately from highdicom, specifically ``SimpleITK>=2.2.1``.
+
         The Volume is converted to a 3D ``SimpleITK.Image``. If
         its array's current datatype is not supported by SimpleITK,
         it is safely cast to a compatible type where possible. If
@@ -3693,6 +3696,9 @@ class Volume(_VolumeBase):
     ) -> Self:
         """Construct a Volume from a `SimpleITK.Image`.
 
+        This method requires an optional dependency to be installed
+        separately from highdicom, specifically ``SimpleITK>=2.2.1``.
+
         The ``SimpleITK.Image`` is converted to a 3D Volume.
         Spatial metadata (spacing, direction, origin) is preserved
         with both highdicom and SimpletITK using "LPS" convention.
@@ -3748,6 +3754,9 @@ class Volume(_VolumeBase):
 
     def to_itk(self) -> 'itk.Image':  # noqa: F821
         """Convert the volume to `itk.Image` format.
+
+        This method requires an optional dependency to be installed
+        separately from highdicom, specifically ``itk>=5.4.0``.
 
         The Volume is converted to a 3D ``itk.image``. If its array's
         current datatype is not supported by ITK, it is safely cast to
@@ -3858,6 +3867,9 @@ class Volume(_VolumeBase):
         frame_of_reference_uid: str | None = None,
     ) -> Self:
         """Construct a Volume from an `itk.Image`.
+
+        This method requires an optional dependency to be installed
+        separately from highdicom, specifically ``itk>=5.4.0``.
 
         The ``itk.Image`` is converted to a 3D Volume.
         Spatial metadata (spacing, direction, origin) is preserved

--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -2871,8 +2871,8 @@ class Volume(_VolumeBase):
             [np.floating, np.integer, np.bool_]
         ]):
             raise ValueError(
-                "Argument 'array' must have an integer, floating point, "
-                f" or boolean dtype, received '{array.dtype}'."
+                "Array must have an integer, floating point, "
+                f" or boolean dtype, received '{value.dtype}'."
             )
 
         self._array = value

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1369,12 +1369,12 @@ def test_match_geometry_segmentation():
         str
     ]
 )
-def test_dtype_restriction(dtype):
+def test_init_dtype(dtype):
     if any([
         np.issubdtype(dtype, t) for t in
         [np.floating, np.integer, np.bool_]
     ]):
-        volume = Volume.from_attributes(
+        Volume.from_attributes(
             array=np.zeros((10, 10, 10), dtype=dtype),
             image_position=(0.0, 0.0, 0.0),
             image_orientation=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0),
@@ -1382,22 +1382,6 @@ def test_dtype_restriction(dtype):
             spacing_between_slices=1.0,
             coordinate_system='PATIENT',
         )
-
-        for disallowed_dtype in [
-            np.complex64,
-            complex,
-            np.complex128,
-            np.complex256,
-            str
-        ]:
-            with pytest.raises(
-                ValueError,
-                match=(
-                    "Array must have a dtype of float, integer,"
-                    " or bool, received"
-                )
-            ):
-                volume.array = np.zeros((10, 10, 10), dtype=disallowed_dtype)
 
     else:
         with pytest.raises(
@@ -1407,7 +1391,7 @@ def test_dtype_restriction(dtype):
                 " or bool, received"
             )
         ):
-            volume = Volume.from_attributes(
+            Volume.from_attributes(
                 array=np.zeros((10, 10, 10), dtype=dtype),
                 image_position=(0.0, 0.0, 0.0),
                 image_orientation=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0),
@@ -1415,3 +1399,33 @@ def test_dtype_restriction(dtype):
                 spacing_between_slices=1.0,
                 coordinate_system='PATIENT',
             )
+
+
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        np.complex64,
+        complex,
+        np.complex128,
+        np.complex256,
+        str
+    ]
+)
+def test_reassign_dtype(dtype):
+    volume = Volume.from_attributes(
+        array=np.zeros((10, 10, 10), dtype=np.uint8),
+        image_position=(0.0, 0.0, 0.0),
+        image_orientation=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0),
+        pixel_spacing=(1.0, 1.0),
+        spacing_between_slices=1.0,
+        coordinate_system='PATIENT',
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Array must have a dtype of float, integer,"
+            " or bool, received"
+        )
+    ):
+        volume.array = np.zeros((10, 10, 10), dtype=dtype)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1341,3 +1341,77 @@ def test_match_geometry_segmentation():
         seg_vol_from_matched_dataset.array,
         seg_volume_matched.array
     )
+
+
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        int,
+        np.float16,
+        np.float32,
+        np.float64,
+        float,
+        np.float128,
+        np.complex64,
+        complex,
+        np.complex128,
+        np.complex256,
+        np.bool_,
+        bool,
+        str
+    ]
+)
+def test_dtype_restriction(dtype):
+    if any([
+        np.issubdtype(dtype, t) for t in
+        [np.floating, np.integer, np.bool_]
+    ]):
+        volume = Volume.from_attributes(
+            array=np.zeros((10, 10, 10), dtype=dtype),
+            image_position=(0.0, 0.0, 0.0),
+            image_orientation=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0),
+            pixel_spacing=(1.0, 1.0),
+            spacing_between_slices=1.0,
+            coordinate_system='PATIENT',
+        )
+
+        for disallowed_dtype in [
+            np.complex64,
+            complex,
+            np.complex128,
+            np.complex256,
+            str
+        ]:
+            with pytest.raises(
+                ValueError,
+                match=(
+                    "Array must have a dtype of float, integer,"
+                    " or bool, received"
+                )
+            ):
+                volume.array = np.zeros((10, 10, 10), dtype=disallowed_dtype)
+
+    else:
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Argument 'array' must have a dtype of float, integer,"
+                " or bool, received"
+            )
+        ):
+            volume = Volume.from_attributes(
+                array=np.zeros((10, 10, 10), dtype=dtype),
+                image_position=(0.0, 0.0, 0.0),
+                image_orientation=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0),
+                pixel_spacing=(1.0, 1.0),
+                spacing_between_slices=1.0,
+                coordinate_system='PATIENT',
+            )

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1387,8 +1387,8 @@ def test_init_dtype(dtype):
         with pytest.raises(
             ValueError,
             match=(
-                "Argument 'array' must have a dtype of float, integer,"
-                " or bool, received"
+                "Array must have an integer, floating point,"
+                " or boolean dtype, received"
             )
         ):
             Volume.from_attributes(
@@ -1404,10 +1404,26 @@ def test_init_dtype(dtype):
 @pytest.mark.parametrize(
     'dtype',
     [
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        int,
+        np.float16,
+        np.float32,
+        np.float64,
+        float,
+        np.float128,
         np.complex64,
         complex,
         np.complex128,
         np.complex256,
+        np.bool_,
+        bool,
         str
     ]
 )
@@ -1421,11 +1437,18 @@ def test_reassign_dtype(dtype):
         coordinate_system='PATIENT',
     )
 
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Array must have a dtype of float, integer,"
-            " or bool, received"
-        )
-    ):
+    if any([
+        np.issubdtype(dtype, t) for t in
+        [np.floating, np.integer, np.bool_]
+    ]):
         volume.array = np.zeros((10, 10, 10), dtype=dtype)
+
+    else:
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Array must have an integer, floating point,"
+                " or boolean dtype, received"
+            )
+        ):
+            volume.array = np.zeros((10, 10, 10), dtype=dtype)


### PR DESCRIPTION
Added checks to the volume init and setter methods to ensure volumes have float, integer, or bool types. A new test was added to verify that volumes cannot be instantiated with an array of an unsupported data type nor changed after instantiation to a new data type that is unsupported.