### PR TITLE
Swap code used for source images in measurement groups

### DIFF
--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -230,9 +230,9 @@ class SourceImageForMeasurementGroup(ImageContentItem):
                 )
         super().__init__(
             name=CodedConcept(
-                value='260753009',
-                scheme_designator='SCT',
-                meaning='Source',
+                value='121112',
+                scheme_designator='DCM',
+                meaning='Source of Measurement',
             ),
             referenced_sop_class_uid=referenced_sop_class_uid,
             referenced_sop_instance_uid=referenced_sop_instance_uid,

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -3207,12 +3207,24 @@ class MeasurementsAndQualitativeEvaluations(
     def source_images(self) -> list[SourceImageForMeasurementGroup]:
         """List[highdicom.sr.SourceImageForMeasurementGroup]: source images"""
         root_item = self[0]
-        matches = find_content_items(
-            root_item,
-            name=_SOURCE,
-            value_type=ValueTypeValues.IMAGE,
-            relationship_type=RelationshipTypeValues.CONTAINS
-        )
+
+        # Allowable codes for source images. Per the invocation of TID1501 with
+        # ImagePurpose=CID7551, this should probably be DCM "Source of
+        # Measurement". However, highdicom previously used SCT "Source"
+        # following the note for row 10 of TID1501. So we include both variants
+        # here
+        source_codes = [_SOURCE, codes.DCM.SourceOfMeasurement]
+
+        matches = []
+        for name in source_codes:
+            matches.extend(
+                find_content_items(
+                    root_item,
+                    name=name,
+                    value_type=ValueTypeValues.IMAGE,
+                    relationship_type=RelationshipTypeValues.CONTAINS
+                )
+            )
         if len(matches) > 0:
             return [
                 SourceImageForMeasurementGroup.from_dataset(m) for m in matches
@@ -5095,12 +5107,20 @@ class MeasurementReport(Template):
                 (referenced_sop_instance_uid is not None) or
                 (referenced_sop_class_uid is not None)
             ):
-                matches_uids = _contains_image_items(
-                    group_item,
-                    name=_SOURCE,
-                    referenced_sop_class_uid=referenced_sop_class_uid,
-                    referenced_sop_instance_uid=referenced_sop_instance_uid,
-                    relationship_type=RelationshipTypeValues.CONTAINS
+                # Allowable codes for source images. Per the invocation of
+                # TID1501 with ImagePurpose=CID7551, this should probably be
+                # DCM "Source of Measurement". However, highdicom previously
+                # used SCT "Source" following the note for row 10 of TID1501.
+                # So we include both variants here
+                source_codes = [_SOURCE, codes.DCM.SourceOfMeasurement]
+                matches_uids = any(
+                    _contains_image_items(
+                        group_item,
+                        name=name,
+                        referenced_sop_class_uid=referenced_sop_class_uid,
+                        referenced_sop_instance_uid=referenced_sop_instance_uid,
+                        relationship_type=RelationshipTypeValues.CONTAINS
+                    ) for name in source_codes
                 )
                 matches.append(matches_uids)
 


### PR DESCRIPTION
Previously highdicom has used the code (SCT, 260753009, "Source") for source images included in Measurements and Qualitative Evaluations (TID1501). This decision was based on the note corresponding to row 10 in the [relevant template definition](https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_1501). This is likely incorrect however, since the note in row 10 applies only when the `$ImagePurpose` parameter is empty, but when invoked from TID1500, `$ImagePurpose` has value [CID7551](https://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7551.html), and therefore a value chosen from that context group should be used. 

This PR changes the code used within to encode source images to (DCM, 121112, "Source of Measurement"), because the other values do not align with the way TID1501 is used in highdicom. Parsing will be compatible with both the old and the new code