### PR TITLE
Remove algorithm identification from background class

### DIFF
--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -1444,6 +1444,15 @@ class Segmentation(_Image):
             # descriptions having a positive value can remain in place.
             bg_description.SegmentNumber = 0
 
+            # Remove the algorithm identification sequence, since it is not
+            # actually required (highdicom is stricter than the standard here)
+            # and doesn't make sense for a background class
+            if bg_algo_id is not None:
+                delattr(
+                    bg_description,
+                    'SegmentationAlgorithmIdentificationSequence'
+                )
+
             self.SegmentSequence = [
                 bg_description,
                 *segment_descriptions

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -1724,6 +1724,19 @@ class TestSegmentation:
         assert not hasattr(instance, 'ExtendedOffsetTable')
         assert not hasattr(instance, 'ExtendedOffsetTableLengths')
 
+        # Segment descriptions include background
+        assert (
+            len(instance.SegmentSequence) ==
+            len(self._segment_descriptions) + 1
+        )
+
+        # Background segment has no algorithm identification
+        bg_desc = instance.SegmentSequence[0]
+        assert not hasattr(
+            bg_desc,
+            'SegmentationAlgorithmIdentificationSequence'
+        )
+
     def test_construction_9(self):
         # A label with a palette color LUT
         instance = Segmentation(


### PR DESCRIPTION
Highdicom automatically populates details of the background segment description when a LABELMAP segmentation is created. This currently includes the segmentation algorithm identification sequence, which is copied from the first segment the user passes. However, this information is not required by the standard (only by the highdicom implementation of SegmentDescription as an opinionated decision), so we are free to remove this information from the background segment description.

Since it's not really clear how to decide which algorithm if any "created" the background class, this PR removes the algorithm identification information from the background segment.