### PR TITLE
Add family and manufacturer to Algorithm Identification template

### DIFF
--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -74,7 +74,8 @@ class AlgorithmIdentificationSequence(DataElementSequence):
         name: str
             Name of the algorithm
         family: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept]
-            Kind of algorithm family
+            Kind of algorithm family. See :dcm:`CID 7162
+            <part16/sect_CID_7162.html>` for recommended values.
         version: str
             Version of the algorithm
         source: str, optional

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -697,20 +697,26 @@ class AlgorithmIdentification(Template):
         self,
         name: str,
         version: str,
-        parameters: Sequence[str] | None = None
+        parameters: Sequence[str] | None = None,
+        family: Code | CodedConcept | None = None,
+        manufacturer: str | None = None,
     ) -> None:
         """
 
         Parameters
         ----------
         name: str
-            name of the algorithm
+            Name of the algorithm
         version: str
-            version of the algorithm
+            Version of the algorithm
         parameters: Union[Sequence[str], None], optional
-            parameters of the algorithm
+            Parameters of the algorithm
+        manufacturer: str | None, optional
+            Manufacturer of the algorithm
+        family: pydicom.sr.coding.Code | highdicom.sr.CodedConcept | None, optional
+            Algorithm family
 
-        """
+        """  # noqa: E501
         super().__init__()
         name_item = TextContentItem(
             name=CodedConcept(
@@ -732,6 +738,17 @@ class AlgorithmIdentification(Template):
             relationship_type=RelationshipTypeValues.HAS_CONCEPT_MOD
         )
         self.append(version_item)
+        if manufacturer is not None:
+            manufacturer_item = TextContentItem(
+                name=CodedConcept(
+                    value='122405',
+                    meaning='Algorithm Manufacturer',
+                    scheme_designator='DCM'
+                ),
+                value=manufacturer,
+                relationship_type=RelationshipTypeValues.HAS_CONCEPT_MOD
+            )
+            self.append(manufacturer_item)
         if parameters is not None:
             for param in parameters:
                 parameter_item = TextContentItem(
@@ -744,6 +761,17 @@ class AlgorithmIdentification(Template):
                     relationship_type=RelationshipTypeValues.HAS_CONCEPT_MOD
                 )
                 self.append(parameter_item)
+        if family is not None:
+            family_item = CodeContentItem(
+                name=CodedConcept(
+                    value='111000',
+                    meaning='Algorithm Family',
+                    scheme_designator='DCM'
+                ),
+                value=family,
+                relationship_type=RelationshipTypeValues.HAS_CONCEPT_MOD
+            )
+            self.append(family_item)
 
 
 class TrackingIdentifier(Template):

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -423,6 +423,7 @@ class TestAlgorithmIdentification(unittest.TestCase):
         assert algo_id[-1].ConceptCodeSequence[0].CodeValue == \
             self._family.value
 
+
 class TestMeasurementStatisticalProperties(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -379,6 +379,8 @@ class TestAlgorithmIdentification(unittest.TestCase):
         self._name = "Foo's Method"
         self._version = '1.0'
         self._parameters = ['spam=True', 'eggs=False']
+        self._manufacturer = 'Foo Corp.'
+        self._family = codes.DCM.ArtificialIntelligence
 
     def test_construction_basic(self):
         algo_id = AlgorithmIdentification(
@@ -393,24 +395,33 @@ class TestAlgorithmIdentification(unittest.TestCase):
             codes.DCM.AlgorithmVersion.value
         assert algo_id[1].TextValue == self._version
 
-    def test_construction_parameters(self):
+    def test_construction_full(self):
+        # With all optional parameters
         algo_id = AlgorithmIdentification(
             name=self._name,
             version=self._version,
             parameters=self._parameters,
+            manufacturer=self._manufacturer,
+            family=self._family,
         )
-        assert len(algo_id) == 2 + len(self._parameters)
+        assert len(algo_id) == 4 + len(self._parameters)
         assert algo_id[0].ConceptNameCodeSequence[0].CodeValue == \
             codes.DCM.AlgorithmName.value
         assert algo_id[0].TextValue == self._name
         assert algo_id[1].ConceptNameCodeSequence[0].CodeValue == \
             codes.DCM.AlgorithmVersion.value
         assert algo_id[1].TextValue == self._version
-        for i, param in enumerate(self._parameters, start=2):
+        assert algo_id[2].ConceptNameCodeSequence[0].CodeValue == \
+            codes.DCM.AlgorithmManufacturer.value
+        assert algo_id[2].TextValue == self._manufacturer
+        for i, param in enumerate(self._parameters, start=3):
             assert algo_id[i].ConceptNameCodeSequence[0].CodeValue == \
                 codes.DCM.AlgorithmParameters.value
             assert algo_id[i].TextValue == param
-
+        assert algo_id[-1].ConceptNameCodeSequence[0].CodeValue == \
+            codes.DCM.AlgorithmFamily.value
+        assert algo_id[-1].ConceptCodeSequence[0].CodeValue == \
+            self._family.value
 
 class TestMeasurementStatisticalProperties(unittest.TestCase):
 


### PR DESCRIPTION
Add some more optional parameters (manufacturer and family) to the TID 4019 Algorithm Identification template 