### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  # Keep the actions used in .github/workflows/ up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Bundle all action bumps into one PR per run instead of one per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "CI"


### PR DESCRIPTION
I relatively recently discovered this, and added to the repos I maintain. This is important, since sometimes actions might start failing due to outdated version, and errors might be confusing. Also, sometime older versions may get deprecated (eg planned phasing out of Node 20).