### PR TITLE
Treat None Rescale Intercept/Slope as missing without raising exception #418

### DIFF
--- a/src/highdicom/image.py
+++ b/src/highdicom/image.py
@@ -623,14 +623,18 @@ class _CombinedPixelTransform:
                         else:
                             sub_ds = ds
 
-                        if (
-                            'RescaleSlope' in sub_ds or
-                            'RescaleIntercept' in sub_ds
-                        ):
+                        # Rescale intercept and slope should not be empty,
+                        # but this has been observed in some data and
+                        # should be handled by assuming slope=1, intercept=0
+                        rescale_slope = sub_ds.get('RescaleSlope', None)
+                        rescale_intercept = sub_ds.get('RescaleIntercept', None)
+
+                        if rescale_slope or rescale_intercept:
                             modality_slope_intercept = (
-                                float(sub_ds.get('RescaleSlope', 1.0)),
-                                float(sub_ds.get('RescaleIntercept', 0.0))
+                                float(rescale_slope or 1.0),
+                                float(rescale_intercept or 0.0)
                             )
+
                             self.applies_to_all_frames = (
                                 self.applies_to_all_frames and is_shared
                             )

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1017,6 +1017,31 @@ def test_combined_transform_pmap_rwvm_lut():
         tf = _CombinedPixelTransform(pmap, output_dtype=np.float32)
 
 
+def test_empty_rescale_slope_intercept_behaves_as_missing():
+    # Construct a CT image with None RescaleSlope/RescaleIntercept
+    file_path = Path(__file__)
+    data_dir = file_path.parent.parent.joinpath('data')
+    f = data_dir / 'test_files/ct_image.dcm'
+
+    # try all combinations of missing and None: None is treated as missing
+    for intercept_none in [False, True]:
+        for slope_none in [False, True]:
+            dataset = pydicom.dcmread(f)
+
+            del dataset.RescaleIntercept
+            del dataset.RescaleSlope
+
+            if intercept_none:
+                dataset.RescaleIntercept = None
+
+            if slope_none:
+                dataset.RescaleSlope = None
+
+            # parsing succeeds and defaults to no effective slope intercept
+            tf = _CombinedPixelTransform(dataset)
+            assert tf._effective_slope_intercept is None
+
+
 def test_get_volume_multiframe_ct():
     im = imread(get_testdata_file('eCT_Supplemental.dcm'))
     volume = im.get_volume()


### PR DESCRIPTION
Treat None Rescale Intercept/Slope as missing without raising exception. 

Fixes: #418

I wasn't sure what kind of tests you prefer, so I wrote one that expects parsing to succeed without exceptions and  `_effective_slope_intercept` to be `None` for all combinations of missing/None rescale slope and intercept tags.

Confirmed this test was failing with exception before the code fix.

Happy to update if you think this should be tested differently.