### PR TITLE
Disallow segmented LUT in presentation states

### DIFF
--- a/src/highdicom/pr/content.py
+++ b/src/highdicom/pr/content.py
@@ -1767,12 +1767,18 @@ class AdvancedBlending(Dataset):
                 logger.debug('no VOI LUT attributes found in referenced images')
 
         # Palette Color Lookup Table
-        palette_color_lut_item = Dataset()
-        _add_palette_color_lookup_table_attributes(
-            palette_color_lut_item,
-            palette_color_lut_transformation=palette_color_lut_transformation
-        )
-        self.PaletteColorLookupTableSequence = [palette_color_lut_item]
+        if palette_color_lut_transformation is not None:
+            palette_color_lut_item = Dataset()
+            if palette_color_lut_transformation.is_segmented:
+                raise ValueError(
+                    "palette_color_lut_transformation for presentation states "
+                    "may not be segmented."
+                )
+            _add_palette_color_lookup_table_attributes(
+                palette_color_lut_item,
+                palette_color_lut_transformation
+            )
+            self.PaletteColorLookupTableSequence = [palette_color_lut_item]
 
 
 class BlendingDisplayInput(Dataset):

--- a/src/highdicom/pr/sop.py
+++ b/src/highdicom/pr/sop.py
@@ -614,6 +614,11 @@ class PseudoColorSoftcopyPresentationState(SOPClass):
                 "palette_color_lut_transformation for presentation states must "
                 "have 16 bits."
             )
+        if palette_color_lut_transformation.is_segmented:
+            raise ValueError(
+                "palette_color_lut_transformation for presentation states may "
+                "not be segmented."
+            )
         _add_palette_color_lookup_table_attributes(
             self,
             palette_color_lut_transformation=palette_color_lut_transformation

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -799,35 +799,29 @@ class TestAdvancedBlending(unittest.TestCase):
                 )
             ],
             palette_color_lut_transformation=PaletteColorLUTTransformation(
-                red_lut=SegmentedPaletteColorLUT(
+                red_lut=PaletteColorLUT(
                     first_mapped_value=0,
-                    segmented_lut_data=np.array(
-                        [
-                            0, 1, 0,
-                            1, 255, 0,
-                        ],
+                    lut_data=np.arange(
+                        0,
+                        256,
                         dtype=np.uint16
                     ),
                     color='red'
                 ),
-                green_lut=SegmentedPaletteColorLUT(
+                green_lut=PaletteColorLUT(
                     first_mapped_value=0,
-                    segmented_lut_data=np.array(
-                        [
-                            0, 1, 0,
-                            1, 255, 0,
-                        ],
+                    lut_data=np.arange(
+                        0,
+                        256,
                         dtype=np.uint16
                     ),
                     color='green'
                 ),
-                blue_lut=SegmentedPaletteColorLUT(
+                blue_lut=PaletteColorLUT(
                     first_mapped_value=0,
-                    segmented_lut_data=np.array(
-                        [
-                            0, 1, 0,
-                            1, 255, 255,
-                        ],
+                    lut_data=np.arange(
+                        0,
+                        256,
                         dtype=np.uint16
                     ),
                     color='blue'
@@ -865,9 +859,9 @@ class TestAdvancedBlending(unittest.TestCase):
         assert item.BluePaletteColorLookupTableDescriptor[0] == 256
         assert item.BluePaletteColorLookupTableDescriptor[1] == 0
         assert item.BluePaletteColorLookupTableDescriptor[2] == 16
-        assert len(item.SegmentedRedPaletteColorLookupTableData) == 12
-        assert len(item.SegmentedGreenPaletteColorLookupTableData) == 12
-        assert len(item.SegmentedBluePaletteColorLookupTableData) == 12
+        assert len(item.RedPaletteColorLookupTableData) == 512
+        assert len(item.GreenPaletteColorLookupTableData) == 512
+        assert len(item.BluePaletteColorLookupTableData) == 512
 
         assert not hasattr(ds, 'ContentDescription')
         assert not hasattr(ds, 'ConceptNameCodeSequence')
@@ -875,6 +869,61 @@ class TestAdvancedBlending(unittest.TestCase):
         assert not hasattr(ds, 'RescaleSlope')
         assert not hasattr(ds, 'RescaleIntercept')
         assert not hasattr(ds, 'ModalityLUTSequence')
+
+    def test_segmented_lut(self):
+        ref_images = [self._sm_image, self._sm_image_reversed]
+
+        msg = (
+            "palette_color_lut_transformation for presentation states "
+            "may not be segmented."
+        )
+
+        with pytest.raises(ValueError, match=msg):
+            AdvancedBlending(
+                referenced_images=ref_images,
+                blending_input_number=1,
+                voi_lut_transformations=[
+                    SoftcopyVOILUTTransformation(
+                        window_center=12.0,
+                        window_width=24.0,
+                    )
+                ],
+                palette_color_lut_transformation=PaletteColorLUTTransformation(
+                    red_lut=SegmentedPaletteColorLUT(
+                        first_mapped_value=0,
+                        segmented_lut_data=np.array(
+                            [
+                                0, 1, 0,
+                                1, 255, 0,
+                            ],
+                            dtype=np.uint16
+                        ),
+                        color='red'
+                    ),
+                    green_lut=SegmentedPaletteColorLUT(
+                        first_mapped_value=0,
+                        segmented_lut_data=np.array(
+                            [
+                                0, 1, 0,
+                                1, 255, 0,
+                            ],
+                            dtype=np.uint16
+                        ),
+                        color='green'
+                    ),
+                    blue_lut=SegmentedPaletteColorLUT(
+                        first_mapped_value=0,
+                        segmented_lut_data=np.array(
+                            [
+                                0, 1, 0,
+                                1, 255, 255,
+                            ],
+                            dtype=np.uint16
+                        ),
+                        color='blue'
+                    )
+                )
+            )
 
 
 class TestBlendingDisplay(unittest.TestCase):


### PR DESCRIPTION
Segmented LUTs should not be included in Presentation States, per [the standard](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.9.html#table_C.7-22a)

This PR disallows the inclusion of segmented LUTs in presentation states