### PR TITLE
Add new "get pixels by source" methods

### DIFF
--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -227,10 +227,54 @@ that could be used to form a :class:`highdicom.Volume`). This is optional,
 Legacy Converted Enhanced images that are not volumes are still entirely valid
 according to the DICOM standard.
 
+Reading Legacy Converted Enhanced Images
+----------------------------------------
+
+You can read in existing legacy converted enhanced images with the
+:func:`highdicom.legacy.lceread` function. Like the more general
+:func:`highdicom.imread` function, this supports a
+``lazy_frame_retrieval`` parameter to enable :ref:`lazy`.
+
+Once read, the legacy converted images can be treated just like any DICOM image
+because the Legacy Converted Enhanced classes are subclasses of
+:class:`highdicom.Image` (see :ref:`image`). Additionally, they support an
+additional method, :meth:`get_pixels_by_legacy_source_instance`, that allows
+you to request frames of the legacy converted enhanced image by specifying the
+SOP Instance UID(s) of the original legacy instances they were converted from
+(rather than the frame numbers in the converted image).
+
+.. code-block:: python
+
+  import highdicom as hd
+
+
+  # Read the legacy converted enhanced image from disk
+  lce_image = hd.legacy.lceread("...")
+
+  # Get a Volume (assuming frames are regularly-spaced)
+  volume = lce_image.get_volume()
+
+  # Retrieve a single frame by providing the legacy SOP instance UID as a
+  # single string. This will return a 2D numpy array
+  frame = lce_image.get_pixels_by_legacy_source_instance(
+      "1.2.826.0.1.3680043.10.511.3.1090449243900474088982677898136506"
+  )
+
+  # Retrieve multiple ordered frames by providing the legacy SOP instance UIDs in a
+  # list of strings. This will return a 3D numpy array with frames stacked down the
+  # first dimension
+  frames = lce_image.get_pixels_by_legacy_source_instance(
+      [
+          "1.2.826.0.1.3680043.10.511.3.1090449243900474088982677898136506",
+          "1.2.826.0.1.3680043.10.511.3.1090449243900474088982677898136507",
+          "1.2.826.0.1.3680043.10.511.3.1090449243900474088982677898136508",
+      ]
+  )
+
 "Real-World" Examples Using Imaging Data Commons Data
 -----------------------------------------------------
 
-Below, we give three examples of converted "real-world" legacy CT/MR/PET series
+Below, we give three examples of converting "real-world" legacy CT/MR/PET series
 into the corresponding Legacy Converted Enhanced Image. These examples use
 publicly accessible data from the Imaging Data Commons (`IDC`_) project, so you
 should be able to run these code snippets directly to retrieve the input data.

--- a/src/highdicom/image.py
+++ b/src/highdicom/image.py
@@ -5182,7 +5182,8 @@ class _Image(SOPClass):
         index values.
 
         """
-        self._file_reader = None
+        if not hasattr(self, '_file_reader'):
+            self._file_reader = None
         self._coordinate_system = get_image_coordinate_system(
             self
         )
@@ -5350,6 +5351,8 @@ class _Image(SOPClass):
             (0x0020_9111, 0x0020_9057),
             # RealWorldValueMappingSequence/LUTLabel
             (0x0040_9096, 0x0040_9210),
+            # ConversionSourceAttributesSequence/ReferencedSOPInstanceUID
+            (0x0020_9172, 0x0008_1155),
         ]:
             if ptr in self._dim_ind_pointers:
                 # Skip if this attribute is already indexed due to being a
@@ -5662,6 +5665,12 @@ class _Image(SOPClass):
 
         for i, t in enumerate(extra_collection_pointers):
             vr, vm_str, _, _, kw = get_entry(t)
+
+            if t == 0x0008_1155:
+                # Special case for referenced sop instance uid to differentiate
+                # from the derivation source sequence (those values are put
+                # into a separate table)
+                kw = 'ConversionSourceAttributesReferencedSOPInstanceUID'
 
             # Add column for dimension value
             # For this to be possible, must have a fixed VM
@@ -7195,6 +7204,12 @@ class _Image(SOPClass):
                 elif p == 'SpatialLocationsPreserved':
                     table_name = 'FrameReferenceLUT'
                     col_name = 'SpatialLocationsPreserved'
+                    python_type = str
+                elif p == 'ConversionSourceAttributesReferencedSOPInstanceUID':
+                    table_name = 'FrameLUT'
+                    col_name = (
+                        'ConversionSourceAttributesReferencedSOPInstanceUID'
+                    )
                     python_type = str
                 else:
                     t = tag_for_keyword(p)
@@ -8913,9 +8928,10 @@ class Image(_Image):
 
         Parameters
         ----------
-        source_sop_instance_uids: str
-            SOP Instance UID of the source instances for which frames
-            are requested. The requested frames
+        source_sop_instance_uids: Sequence[str]
+            SOP Instance UIDs of the source instances for which frames
+            are requested. The requested frames are stacked down the first
+            dimension of the returned array, in the order given here.
         ignore_spatial_locations: bool, optional
            Ignore whether or not spatial locations were preserved in the
            derivation of the frames from the source frames. In some images, the

--- a/src/highdicom/image.py
+++ b/src/highdicom/image.py
@@ -5956,8 +5956,8 @@ class _Image(SOPClass):
             )
         if not self._has_frame_references:
             raise RuntimeError(
-                'Indexing via source frames is not possible because frames '
-                'do not contain information about source frames.'
+                'Indexing via source frames is not possible because the '
+                'image does not contain information about source frames.'
             )
 
         # Check that all frame numbers requested actually exist
@@ -5969,23 +5969,32 @@ class _Image(SOPClass):
             if len(missing_uids) > 0:
                 msg = (
                     f'SOP Instance UID(s) {list(missing_uids)} do not match '
-                    'any referenced source instances. To return an empty '
-                    'segmentation mask in this situation, use the '
+                    'any referenced source instances. To return an array '
+                    'of zeros in this situation, use the '
                     '"assert_missing_frames_are_empty" parameter.'
                 )
                 raise KeyError(msg)
 
             if source_frame_numbers is not None:
                 max_frame_number = (
-                    self._get_max_referenced_frame_number()
+                    self._get_max_referenced_frame_number(
+                        source_sop_instance_uids[0]
+                    )
                 )
+
+                if max_frame_number is None:
+                    raise RuntimeError(
+                        "Image does not record referenced frame numbers "
+                        "for the given instance."
+                    )
+
                 for f in source_frame_numbers:
                     if f > max_frame_number:
                         msg = (
                             f'Source frame number {f} is larger than any '
                             'referenced source frame, so highdicom cannot be '
-                            'certain that it is valid. To return an empty '
-                            'segmentation mask in this situation, use the '
+                            'certain that it is valid. To return an array '
+                            'of zeros in this situation, use the '
                             "'assert_missing_frames_are_empty' parameter."
                         )
                         raise ValueError(msg)
@@ -6221,12 +6230,21 @@ class _Image(SOPClass):
             )
         }
 
-    def _get_max_referenced_frame_number(self) -> int:
+    def _get_max_referenced_frame_number(
+        self,
+        source_sop_instance_uid: str,
+    ) -> int | None:
         """Get highest frame number of any referenced frame.
 
         Absent access to the referenced dataset itself, being less than this
         value is a sufficient condition for the existence of a frame number
         in the source image.
+
+        Parameters
+        ----------
+        source_sop_instance_uid: str
+            SOP instance UID of the referenced image for which the highest
+            referenced frame number is requested.
 
         Returns
         -------
@@ -6236,7 +6254,8 @@ class _Image(SOPClass):
         """
         cur = self._db_con.cursor()
         return cur.execute(
-            'SELECT MAX(ReferencedFrameNumber) FROM FrameReferenceLUT'
+            'SELECT MAX(ReferencedFrameNumber) FROM FrameReferenceLUT '
+            f"WHERE ReferencedSOPInstanceUID='{source_sop_instance_uid}'"
         ).fetchone()[0]
 
     def is_indexable_as_total_pixel_matrix(self) -> bool:
@@ -8857,6 +8876,428 @@ class Image(_Image):
 
             return self._get_pixels_by_frame(
                 spatial_shape=output_shape,
+                indices_iterator=indices,
+                apply_real_world_transform=apply_real_world_transform,
+                real_world_value_map_selector=real_world_value_map_selector,
+                apply_modality_transform=apply_modality_transform,
+                apply_voi_transform=apply_voi_transform,
+                voi_transform_selector=voi_transform_selector,
+                voi_output_range=voi_output_range,
+                apply_presentation_lut=apply_presentation_lut,
+                apply_palette_color_lut=apply_palette_color_lut,
+                apply_icc_profile=apply_icc_profile,
+                dtype=dtype,
+            )
+
+    def get_pixels_by_source_instance(
+        self,
+        source_sop_instance_uids: Sequence[str],
+        ignore_spatial_locations: bool = False,
+        assert_missing_frames_are_empty: bool = False,
+        dtype: type | str | np.dtype = np.float64,
+        apply_real_world_transform: bool | None = None,
+        real_world_value_map_selector: int | str | Code | CodedConcept = 0,
+        apply_modality_transform: bool | None = None,
+        apply_voi_transform: bool | None = False,
+        voi_transform_selector: int | str | VOILUTTransformation = 0,
+        voi_output_range: tuple[float, float] = (0.0, 1.0),
+        apply_presentation_lut: bool = True,
+        apply_palette_color_lut: bool | None = None,
+        apply_icc_profile: bool | None = None,
+    ) -> np.ndarray:
+        """Get a pixel array for a list of source instances.
+
+        This is intended to work for any image that is derived from a series of
+        single-frame DICOM image instances, and therefore contains frame-wise
+        references to the source instances.
+
+        Parameters
+        ----------
+        source_sop_instance_uids: str
+            SOP Instance UID of the source instances for which frames
+            are requested. The requested frames
+        ignore_spatial_locations: bool, optional
+           Ignore whether or not spatial locations were preserved in the
+           derivation of the frames from the source frames. In some images, the
+           pixel locations in the frames may not correspond to pixel locations
+           in the frames of the source image from which they were derived. The
+           image may or may not specify whether or not spatial locations are
+           preserved in this way through use of the optional (0028,135A)
+           SpatialLocationsPreserved attribute. If this attribute specifies
+           that spatial locations are not preserved, or is absent from the
+           image, highdicom's default behavior is to disallow indexing by
+           source frames. To override this behavior and retrieve pixels
+           regardless of the presence or value of the spatial locations
+           preserved attribute, set this parameter to True.
+        assert_missing_frames_are_empty: bool, optional
+            Assert that requested source frame numbers that are not referenced
+            by the image contain no segments. If a source frame number is not
+            referenced by the image, highdicom is unable to check that the
+            frame number is valid in the source image. By default, highdicom
+            will raise an error if any of the requested source frames are not
+            referenced in the source image. To override this behavior and
+            return a frame of all zeros for such frames, set this parameter to
+            True.
+        dtype: Union[type, str, numpy.dtype, None]
+            Data type of the returned array. If None, an appropriate type will
+            be chosen automatically. If the returned values are rescaled
+            fractional values, this will be numpy.float32. Otherwise, the
+            smallest unsigned integer type that accommodates all of the output
+            values will be chosen.
+        apply_real_world_transform: bool | None, optional
+            Whether to apply a real-world value map to the frame.
+            A real-world value maps converts stored pixel values to output
+            values with a real-world meaning, either using a LUT or a linear
+            slope and intercept.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if present but no error will be raised if
+            it is not present.
+
+            Note that if the dataset contains both a modality LUT and a real
+            world value map, the real world value map will be applied
+            preferentially. This also implies that specifying both
+            ``apply_real_world_transform`` and ``apply_modality_transform`` to
+            True is not permitted.
+        real_world_value_map_selector: int | str | pydicom.sr.coding.Code | highdicom.sr.coding.CodedConcept, optional
+            Specification of the real world value map to use (multiple may be
+            present in the dataset). If an int, it is used to index the list of
+            available maps. A negative integer may be used to index from the
+            end of the list following standard Python indexing convention. If a
+            str, the string will be used to match the ``"LUTLabel"`` attribute
+            to select the map. If a ``pydicom.sr.coding.Code`` or
+            ``highdicom.sr.coding.CodedConcept``, this will be used to match
+            the units (contained in the ``"MeasurementUnitsCodeSequence"``
+            attribute).
+        apply_modality_transform: bool | None, optional
+            Whether to apply the modality transform (if present in the
+            dataset) to the frame. The modality transform maps stored pixel
+            values to output values, either using a LUT or rescale slope and
+            intercept.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if it is present and no real world value
+            map takes precedence, but no error will be raised if it is not
+            present.
+        apply_voi_transform: bool | None, optional
+            Apply the value-of-interest (VOI) transform (if present in the
+            dataset), which limits the range of pixel values to a particular
+            range of interest using either a windowing operation or a LUT.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if it is present and no real world value
+            map takes precedence, but no error will be raised if it is not
+            present.
+        voi_transform_selector: int | str | highdicom.VOILUTTransformation, optional
+            Specification of the VOI transform to select (multiple may be
+            present). May either be an int or a str. If an int, it is
+            interpreted as a (zero-based) index of the list of VOI transforms
+            to apply. A negative integer may be used to index from the end of
+            the list following standard Python indexing convention. If a str,
+            the string that will be used to match the
+            ``"WindowCenterWidthExplanation"`` or the ``"LUTExplanation"``
+            attributes to choose from multiple VOI transforms. Note that such
+            explanations are optional according to the standard and therefore
+            may not be present. Ignored if ``apply_voi_transform`` is ``False``
+            or no VOI transform is included in the datasets.
+
+            Alternatively, a user-defined
+            :class:`highdicom.VOILUTTransformation` may be supplied.
+            This will override any such transform specified in the dataset.
+        voi_output_range: Tuple[float, float], optional
+            Range of output values to which the VOI range is mapped. Only
+            relevant if ``apply_voi_transform`` is True and a VOI transform is
+            present.
+        apply_palette_color_lut: bool | None, optional
+            Apply the palette color LUT, if present in the dataset. The palette
+            color LUT maps a single sample for each pixel stored in the dataset
+            to a 3 sample-per-pixel color image.
+        apply_presentation_lut: bool, optional
+            Apply the presentation LUT transform to invert the pixel values. If
+            the PresentationLUTShape is present with the value ``'INVERSE'``,
+            or the PresentationLUTShape is not present but the Photometric
+            Interpretation is MONOCHROME1, convert the range of the output
+            pixels corresponds to MONOCHROME2 (in which high values are
+            represent white and low values represent black). Ignored if
+            PhotometricInterpretation is not MONOCHROME1 and the
+            PresentationLUTShape is not present, or if a real world value
+            transform is applied.
+        apply_icc_profile: bool | None, optional
+            Whether colors should be corrected by applying an ICC
+            transform. Will only be performed if metadata contain an
+            ICC Profile.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if it is present, but no error will be
+            raised if it is not present.
+
+        Returns
+        -------
+        pixel_array: numpy.ndarray
+            Pixel array representing the requested image frames.
+
+        """  # noqa: E501
+        # Checks on validity of the inputs
+        if isinstance(source_sop_instance_uids, str):
+            raise TypeError(
+                'source_sop_instance_uids should be a sequence of UIDs, not a '
+                'single UID'
+            )
+        if len(source_sop_instance_uids) == 0:
+            raise ValueError(
+                'Source SOP instance UIDs may not be empty.'
+            )
+
+        # Check that indexing in this way is possible
+        self._check_indexing_with_source_frames(
+            source_sop_instance_uids=source_sop_instance_uids,
+            ignore_spatial_locations=ignore_spatial_locations,
+            assert_missing_frames_are_empty=assert_missing_frames_are_empty,
+        )
+
+        filters: dict[str, str] | None = None
+        if not ignore_spatial_locations:
+            filters = {'SpatialLocationsPreserved': 'YES'}
+
+        with self._iterate_indices_for_stack(
+            stack_indices={
+                'ReferencedSOPInstanceUID': source_sop_instance_uids
+            },
+            allow_missing_values=True,
+            allow_missing_combinations=True,
+            filters=filters,
+        ) as indices:
+
+            return self._get_pixels_by_frame(
+                spatial_shape=len(source_sop_instance_uids),
+                indices_iterator=indices,
+                apply_real_world_transform=apply_real_world_transform,
+                real_world_value_map_selector=real_world_value_map_selector,
+                apply_modality_transform=apply_modality_transform,
+                apply_voi_transform=apply_voi_transform,
+                voi_transform_selector=voi_transform_selector,
+                voi_output_range=voi_output_range,
+                apply_presentation_lut=apply_presentation_lut,
+                apply_palette_color_lut=apply_palette_color_lut,
+                apply_icc_profile=apply_icc_profile,
+                dtype=dtype,
+            )
+
+    def get_pixels_by_source_frame(
+        self,
+        source_sop_instance_uid: str,
+        source_frame_numbers: Sequence[int] | None = None,
+        ignore_spatial_locations: bool = False,
+        assert_missing_frames_are_empty: bool = False,
+        dtype: type | str | np.dtype = np.float64,
+        apply_real_world_transform: bool | None = None,
+        real_world_value_map_selector: int | str | Code | CodedConcept = 0,
+        apply_modality_transform: bool | None = None,
+        apply_voi_transform: bool | None = False,
+        voi_transform_selector: int | str | VOILUTTransformation = 0,
+        voi_output_range: tuple[float, float] = (0.0, 1.0),
+        apply_presentation_lut: bool = True,
+        apply_palette_color_lut: bool | None = None,
+        apply_icc_profile: bool | None = None,
+    ) -> np.ndarray:
+        """Get a pixel array for a list of source instances.
+
+        This is intended to work for any image that is derived from a single,
+        multi-frame DICOM image instance, and therefore contains frame-wise
+        references to the source frames.
+
+        Parameters
+        ----------
+        source_sop_instance_uid: str
+            SOP Instance UID of the source instance that contains the source
+            frames.
+        source_frame_numbers: Sequence[int] | None, optional
+            A sequence of frame numbers (1-based) within the source instance
+            for which frames are requested. If not specified, the consecutive
+            frame numbers from 1 until the maximum number reference in this
+            image (which may not necessarily be the number of frames in the
+            source image) is used.
+        ignore_spatial_locations: bool, optional
+           Ignore whether or not spatial locations were preserved in the
+           derivation of the frames from the source frames. In some images, the
+           pixel locations in the frames may not correspond to pixel locations
+           in the frames of the source image from which they were derived. The
+           image may or may not specify whether or not spatial locations are
+           preserved in this way through use of the optional (0028,135A)
+           SpatialLocationsPreserved attribute. If this attribute specifies
+           that spatial locations are not preserved, or is absent from the
+           image, highdicom's default behavior is to disallow indexing by
+           source frames. To override this behavior and retrieve pixels
+           regardless of the presence or value of the spatial locations
+           preserved attribute, set this parameter to True.
+        assert_missing_frames_are_empty: bool, optional
+            Assert that requested source frame numbers that are not referenced
+            by the image contain no segments. If a source frame number is not
+            referenced by the image, highdicom is unable to check that the
+            frame number is valid in the source image. By default, highdicom
+            will raise an error if any of the requested source frames are not
+            referenced in the source image. To override this behavior and
+            return a frame of all zeros for such frames, set this parameter to
+            True.
+        dtype: Union[type, str, numpy.dtype, None]
+            Data type of the returned array. If None, an appropriate type will
+            be chosen automatically. If the returned values are rescaled
+            fractional values, this will be numpy.float32. Otherwise, the
+            smallest unsigned integer type that accommodates all of the output
+            values will be chosen.
+        apply_real_world_transform: bool | None, optional
+            Whether to apply a real-world value map to the frame.
+            A real-world value maps converts stored pixel values to output
+            values with a real-world meaning, either using a LUT or a linear
+            slope and intercept.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if present but no error will be raised if
+            it is not present.
+
+            Note that if the dataset contains both a modality LUT and a real
+            world value map, the real world value map will be applied
+            preferentially. This also implies that specifying both
+            ``apply_real_world_transform`` and ``apply_modality_transform`` to
+            True is not permitted.
+        real_world_value_map_selector: int | str | pydicom.sr.coding.Code | highdicom.sr.coding.CodedConcept, optional
+            Specification of the real world value map to use (multiple may be
+            present in the dataset). If an int, it is used to index the list of
+            available maps. A negative integer may be used to index from the
+            end of the list following standard Python indexing convention. If a
+            str, the string will be used to match the ``"LUTLabel"`` attribute
+            to select the map. If a ``pydicom.sr.coding.Code`` or
+            ``highdicom.sr.coding.CodedConcept``, this will be used to match
+            the units (contained in the ``"MeasurementUnitsCodeSequence"``
+            attribute).
+        apply_modality_transform: bool | None, optional
+            Whether to apply the modality transform (if present in the
+            dataset) to the frame. The modality transform maps stored pixel
+            values to output values, either using a LUT or rescale slope and
+            intercept.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if it is present and no real world value
+            map takes precedence, but no error will be raised if it is not
+            present.
+        apply_voi_transform: bool | None, optional
+            Apply the value-of-interest (VOI) transform (if present in the
+            dataset), which limits the range of pixel values to a particular
+            range of interest using either a windowing operation or a LUT.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if it is present and no real world value
+            map takes precedence, but no error will be raised if it is not
+            present.
+        voi_transform_selector: int | str | highdicom.VOILUTTransformation, optional
+            Specification of the VOI transform to select (multiple may be
+            present). May either be an int or a str. If an int, it is
+            interpreted as a (zero-based) index of the list of VOI transforms
+            to apply. A negative integer may be used to index from the end of
+            the list following standard Python indexing convention. If a str,
+            the string that will be used to match the
+            ``"WindowCenterWidthExplanation"`` or the ``"LUTExplanation"``
+            attributes to choose from multiple VOI transforms. Note that such
+            explanations are optional according to the standard and therefore
+            may not be present. Ignored if ``apply_voi_transform`` is ``False``
+            or no VOI transform is included in the datasets.
+
+            Alternatively, a user-defined
+            :class:`highdicom.VOILUTTransformation` may be supplied.
+            This will override any such transform specified in the dataset.
+        voi_output_range: Tuple[float, float], optional
+            Range of output values to which the VOI range is mapped. Only
+            relevant if ``apply_voi_transform`` is True and a VOI transform is
+            present.
+        apply_palette_color_lut: bool | None, optional
+            Apply the palette color LUT, if present in the dataset. The palette
+            color LUT maps a single sample for each pixel stored in the dataset
+            to a 3 sample-per-pixel color image.
+        apply_presentation_lut: bool, optional
+            Apply the presentation LUT transform to invert the pixel values. If
+            the PresentationLUTShape is present with the value ``'INVERSE'``,
+            or the PresentationLUTShape is not present but the Photometric
+            Interpretation is MONOCHROME1, convert the range of the output
+            pixels corresponds to MONOCHROME2 (in which high values are
+            represent white and low values represent black). Ignored if
+            PhotometricInterpretation is not MONOCHROME1 and the
+            PresentationLUTShape is not present, or if a real world value
+            transform is applied.
+        apply_icc_profile: bool | None, optional
+            Whether colors should be corrected by applying an ICC
+            transform. Will only be performed if metadata contain an
+            ICC Profile.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if it is present, but no error will be
+            raised if it is not present.
+
+        Returns
+        -------
+        pixel_array: numpy.ndarray
+            Pixel array representing the requested image frames.
+
+        """  # noqa: E501
+        # Checks on validity of the inputs
+        if source_frame_numbers is not None:
+            if len(source_frame_numbers) == 0:
+                raise ValueError(
+                    'Source frame numbers should not be empty.'
+                )
+            if not all(f > 0 for f in source_frame_numbers):
+                raise ValueError(
+                    'Frame numbers are 1-based indices and must be > 0.'
+                )
+
+        # Check that indexing in this way is possible
+        self._check_indexing_with_source_frames(
+            source_sop_instance_uids=[source_sop_instance_uid],
+            source_frame_numbers=source_frame_numbers,
+            ignore_spatial_locations=ignore_spatial_locations,
+            assert_missing_frames_are_empty=assert_missing_frames_are_empty,
+        )
+
+        if source_frame_numbers is None:
+            max_frame = self._get_max_referenced_frame_number(
+                source_sop_instance_uid
+            )
+            max_frame = cast(int, max_frame)  # due to check_indexing_...
+            source_frame_numbers = range(1, max_frame + 1)
+
+        filters = None
+        if not ignore_spatial_locations:
+            filters = {'SpatialLocationsPreserved': 'YES'}
+
+        with self._iterate_indices_for_stack(
+            stack_indices={
+                'ReferencedFrameNumber': list(source_frame_numbers),
+                'ReferencedSOPInstanceUID': (
+                    [source_sop_instance_uid] * len(source_frame_numbers)
+                ),
+            },
+            allow_missing_values=True,
+            allow_missing_combinations=True,
+            filters=filters,
+        ) as indices:
+
+            return self._get_pixels_by_frame(
+                spatial_shape=len(source_frame_numbers),
                 indices_iterator=indices,
                 apply_real_world_transform=apply_real_world_transform,
                 real_world_value_map_selector=real_world_value_map_selector,

--- a/src/highdicom/legacy/sop.py
+++ b/src/highdicom/legacy/sop.py
@@ -24,6 +24,7 @@ from pydicom.dataset import Dataset
 from pydicom.encaps import encapsulate, encapsulate_extended, get_frame
 from pydicom.multival import MultiValue
 from pydicom.tag import BaseTag
+from pydicom.sr.coding import Code
 from pydicom.uid import (
     LegacyConvertedEnhancedCTImageStorage,
     LegacyConvertedEnhancedMRImageStorage,
@@ -41,10 +42,12 @@ from pydicom.valuerep import DT, DA, TM, format_number_as_ds
 
 from highdicom._standard_utils import get_anatomic_region_map
 from highdicom.base_content import ContributingEquipment
+from highdicom.content import VOILUTTransformation
 from highdicom.enum import PhotometricInterpretationValues
 from highdicom.frame import encode_frame, get_lossy_compression_attributes
 from highdicom.image import Image, _Image
 from highdicom.spatial import get_series_volume_positions
+from highdicom.sr import CodedConcept
 from highdicom.uid import UID as hd_UID
 
 from highdicom._standard_utils import (
@@ -2866,6 +2869,200 @@ class _CommonLegacyConvertedEnhancedImage(Image):
                 f"{cls._MODALITY_NAME} image."
             )
         return super().from_dataset(dataset, copy=copy)
+
+    def get_pixels_by_legacy_source_instance(
+        self,
+        legacy_sop_instance_uids: str | Sequence[str],
+        dtype: type | str | np.dtype = np.float64,
+        apply_real_world_transform: bool | None = None,
+        real_world_value_map_selector: int | str | Code | CodedConcept = 0,
+        apply_modality_transform: bool | None = None,
+        apply_voi_transform: bool | None = False,
+        voi_transform_selector: int | str | VOILUTTransformation = 0,
+        voi_output_range: tuple[float, float] = (0.0, 1.0),
+        apply_presentation_lut: bool = True,
+        apply_palette_color_lut: bool | None = None,
+        apply_icc_profile: bool | None = None,
+    ) -> np.ndarray:
+        """Get a pixel array using UIDs of the original legacy series.
+
+        Parameters
+        ----------
+        legacy_sop_instance_uids: str | Sequence[str]
+            SOP Instance UID(s) of the original legacy source instance(s) for
+            which frames are requested. If a string is passed, a single 2D
+            frame is returned. If a list of strings is passed, the requested
+            frames are stacked down the first dimension of the returned array,
+            in the order given here.
+        dtype: Union[type, str, numpy.dtype, None]
+            Data type of the returned array. If None, an appropriate type will
+            be chosen automatically. If the returned values are rescaled
+            fractional values, this will be numpy.float32. Otherwise, the
+            smallest unsigned integer type that accommodates all of the output
+            values will be chosen.
+        apply_real_world_transform: bool | None, optional
+            Whether to apply a real-world value map to the frame.
+            A real-world value maps converts stored pixel values to output
+            values with a real-world meaning, either using a LUT or a linear
+            slope and intercept.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if present but no error will be raised if
+            it is not present.
+
+            Note that if the dataset contains both a modality LUT and a real
+            world value map, the real world value map will be applied
+            preferentially. This also implies that specifying both
+            ``apply_real_world_transform`` and ``apply_modality_transform`` to
+            True is not permitted.
+        real_world_value_map_selector: int | str | pydicom.sr.coding.Code | highdicom.sr.coding.CodedConcept, optional
+            Specification of the real world value map to use (multiple may be
+            present in the dataset). If an int, it is used to index the list of
+            available maps. A negative integer may be used to index from the
+            end of the list following standard Python indexing convention. If a
+            str, the string will be used to match the ``"LUTLabel"`` attribute
+            to select the map. If a ``pydicom.sr.coding.Code`` or
+            ``highdicom.sr.coding.CodedConcept``, this will be used to match
+            the units (contained in the ``"MeasurementUnitsCodeSequence"``
+            attribute).
+        apply_modality_transform: bool | None, optional
+            Whether to apply the modality transform (if present in the
+            dataset) to the frame. The modality transform maps stored pixel
+            values to output values, either using a LUT or rescale slope and
+            intercept.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if it is present and no real world value
+            map takes precedence, but no error will be raised if it is not
+            present.
+        apply_voi_transform: bool | None, optional
+            Apply the value-of-interest (VOI) transform (if present in the
+            dataset), which limits the range of pixel values to a particular
+            range of interest using either a windowing operation or a LUT.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if it is present and no real world value
+            map takes precedence, but no error will be raised if it is not
+            present.
+        voi_transform_selector: int | str | highdicom.VOILUTTransformation, optional
+            Specification of the VOI transform to select (multiple may be
+            present). May either be an int or a str. If an int, it is
+            interpreted as a (zero-based) index of the list of VOI transforms
+            to apply. A negative integer may be used to index from the end of
+            the list following standard Python indexing convention. If a str,
+            the string that will be used to match the
+            ``"WindowCenterWidthExplanation"`` or the ``"LUTExplanation"``
+            attributes to choose from multiple VOI transforms. Note that such
+            explanations are optional according to the standard and therefore
+            may not be present. Ignored if ``apply_voi_transform`` is ``False``
+            or no VOI transform is included in the datasets.
+
+            Alternatively, a user-defined
+            :class:`highdicom.VOILUTTransformation` may be supplied.
+            This will override any such transform specified in the dataset.
+        voi_output_range: Tuple[float, float], optional
+            Range of output values to which the VOI range is mapped. Only
+            relevant if ``apply_voi_transform`` is True and a VOI transform is
+            present.
+        apply_palette_color_lut: bool | None, optional
+            Apply the palette color LUT, if present in the dataset. The palette
+            color LUT maps a single sample for each pixel stored in the dataset
+            to a 3 sample-per-pixel color image.
+        apply_presentation_lut: bool, optional
+            Apply the presentation LUT transform to invert the pixel values. If
+            the PresentationLUTShape is present with the value ``'INVERSE'``,
+            or the PresentationLUTShape is not present but the Photometric
+            Interpretation is MONOCHROME1, convert the range of the output
+            pixels corresponds to MONOCHROME2 (in which high values are
+            represent white and low values represent black). Ignored if
+            PhotometricInterpretation is not MONOCHROME1 and the
+            PresentationLUTShape is not present, or if a real world value
+            transform is applied.
+        apply_icc_profile: bool | None, optional
+            Whether colors should be corrected by applying an ICC
+            transform. Will only be performed if metadata contain an
+            ICC Profile.
+
+            If True, the transform is applied if present, and if not
+            present an error will be raised. If False, the transform will not
+            be applied, regardless of whether it is present. If ``None``, the
+            transform will be applied if it is present, but no error will be
+            raised if it is not present.
+
+        Returns
+        -------
+        pixel_array: numpy.ndarray
+            Pixel array representing the requested image frames. This will be
+            either a 2D array (rows, columns) if the input was a single UID
+            as a string, or a 3D array (frames, rows, columns) if a list of
+            one or more legacy UIDs was provided.
+
+        """  # noqa: E501
+        if isinstance(legacy_sop_instance_uids, str):
+            legacy_sop_instance_uids = [legacy_sop_instance_uids]
+            single_output_frame = True
+        else:
+            single_output_frame = False
+
+        # Checks on validity of the inputs
+        if len(legacy_sop_instance_uids) == 0:
+            raise ValueError(
+                'Source SOP instance UIDs may not be empty.'
+            )
+
+        legacy_uid_set = set(legacy_sop_instance_uids)
+        if len(legacy_uid_set) != len(legacy_sop_instance_uids):
+            raise ValueError(
+                "Duplicate values found in 'source_sop_instance_uids'"
+            )
+
+        allowed_values = {
+            v[0] for v in self._db_con.execute(
+                "SELECT DISTINCT("
+                "ConversionSourceAttributesReferencedSOPInstanceUID) "
+                "FROM FrameLUT;"
+            )
+        }
+        if not legacy_uid_set <= allowed_values:
+            raise ValueError(
+                "One or more provided legacy SOP instance UIDs not "
+                "found in the dataset."
+            )
+
+        with self._iterate_indices_for_stack(
+            stack_indices={
+                'ConversionSourceAttributesReferencedSOPInstanceUID':
+                legacy_sop_instance_uids
+            },
+            allow_missing_values=False,
+            allow_missing_combinations=True,
+        ) as indices:
+
+            pixels = self._get_pixels_by_frame(
+                spatial_shape=len(legacy_sop_instance_uids),
+                indices_iterator=indices,
+                apply_real_world_transform=apply_real_world_transform,
+                real_world_value_map_selector=real_world_value_map_selector,
+                apply_modality_transform=apply_modality_transform,
+                apply_voi_transform=apply_voi_transform,
+                voi_transform_selector=voi_transform_selector,
+                voi_output_range=voi_output_range,
+                apply_presentation_lut=apply_presentation_lut,
+                apply_palette_color_lut=apply_palette_color_lut,
+                apply_icc_profile=apply_icc_profile,
+                dtype=dtype,
+            )
+
+        if single_output_frame:
+            pixels = pixels[0]
+
+        return pixels
 
 
 class LegacyConvertedEnhancedCTImage(_CommonLegacyConvertedEnhancedImage):

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -2278,7 +2278,7 @@ class Segmentation(_Image):
         Parameters
         ----------
         source_sop_instance_uids: str
-            SOP Instance UID of the source instances to for which segmentations
+            SOP Instance UID of the source instances for which segmentations
             are requested.
         segment_numbers: Union[Sequence[int], None], optional
             Sequence containing segment numbers to include. If unspecified,
@@ -2450,7 +2450,7 @@ class Segmentation(_Image):
     def get_pixels_by_source_frame(
         self,
         source_sop_instance_uid: str,
-        source_frame_numbers: Sequence[int],
+        source_frame_numbers: Sequence[int] | None = None,
         segment_numbers: Sequence[int] | None = None,
         combine_segments: bool = False,
         relabel: bool = False,
@@ -2519,9 +2519,12 @@ class Segmentation(_Image):
         source_sop_instance_uid: str
             SOP Instance UID of the source instance that contains the source
             frames.
-        source_frame_numbers: Sequence[int]
+        source_frame_numbers: Sequence[int] | None, optional
             A sequence of frame numbers (1-based) within the source instance
-            for which segmentations are requested.
+            for which segmentations are requested. If not specified, the
+            consecutive frame numbers from 1 until the maximum number reference
+            in this segmentation (which may not necessarily be the number of
+            frames in the source image) is used.
         segment_numbers: Optional[Sequence[int]], optional
             Sequence containing segment numbers to include. If unspecified,
             all segments are included.
@@ -2667,14 +2670,15 @@ class Segmentation(_Image):
                 'Segment numbers may not be empty.'
             )
 
-        if len(source_frame_numbers) == 0:
-            raise ValueError(
-                'Source frame numbers should not be empty.'
-            )
-        if not all(f > 0 for f in source_frame_numbers):
-            raise ValueError(
-                'Frame numbers are 1-based indices and must be > 0.'
-            )
+        if source_frame_numbers is not None:
+            if len(source_frame_numbers) == 0:
+                raise ValueError(
+                    'Source frame numbers should not be empty.'
+                )
+            if not all(f > 0 for f in source_frame_numbers):
+                raise ValueError(
+                    'Frame numbers are 1-based indices and must be > 0.'
+                )
 
         if self.segmentation_type == SegmentationTypeValues.LABELMAP:
             channel_indices = None
@@ -2690,6 +2694,13 @@ class Segmentation(_Image):
             ignore_spatial_locations=ignore_spatial_locations,
             assert_missing_frames_are_empty=assert_missing_frames_are_empty,
         )
+
+        if source_frame_numbers is None:
+            max_frame = self._get_max_referenced_frame_number(
+                source_sop_instance_uid
+            )
+            max_frame = cast(int, max_frame)  # due to check_indexing_...
+            source_frame_numbers = range(1, max_frame + 1)
 
         remap_channel_indices = self._get_segment_remap_values(
             segment_numbers,

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -2187,6 +2187,29 @@ def test_read_function(modality: Modality, lazy: bool) -> None:
         fp.seek(0)
         reread = lceread(fp, lazy_frame_retrieval=lazy)
 
-    assert isinstance(reread, LegacyConvertedClass)
-    assert ('PixelData' in reread) == (not lazy)
-    assert converted.pixel_array.shape == (5, 2, 2)
+        assert isinstance(reread, LegacyConvertedClass)
+        assert ('PixelData' in reread) == (not lazy)
+        assert converted.pixel_array.shape == (5, 2, 2)
+
+        # Request a list of legacy UIDs
+        source_instance_uids = [ds.SOPInstanceUID for ds in legacy_datasets]
+        retrieved_pixels = reread.get_pixels_by_legacy_source_instance(
+            source_instance_uids
+        )
+        assert retrieved_pixels.shape == (5, 2, 2)
+
+        # Request a single legacy UID
+        retrieved_pixels = reread.get_pixels_by_legacy_source_instance(
+            source_instance_uids[1],
+        )
+        assert retrieved_pixels.shape == (2, 2)
+
+        # Request incorrect legacy UISs
+        msg = (
+            "One or more provided legacy SOP instance UIDs not "
+            "found in the dataset."
+        )
+        with pytest.raises(ValueError, match=msg):
+            reread.get_pixels_by_legacy_source_instance(
+                ['1.2.3.4']
+            )

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -355,7 +355,7 @@ class TestParametricMap():
             lut_label='1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[0, 255],
+            value_range=(0, 255),
             intercept=0,
             slope=1
         )
@@ -363,7 +363,7 @@ class TestParametricMap():
             lut_label='1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[-10000.0, 10000.0],
+            value_range=(-10000.0, 10000.0),
             intercept=0,
             slope=1
         )
@@ -485,7 +485,7 @@ class TestParametricMap():
             lut_label='1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[0.0, 1.0],
+            value_range=(0.0, 1.0),
             intercept=0,
             slope=1
         )
@@ -564,7 +564,7 @@ class TestParametricMap():
             lut_label='1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[0, 255],
+            value_range=(0, 255),
             intercept=0,
             slope=1
         )
@@ -631,7 +631,7 @@ class TestParametricMap():
             lut_label='1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[0, 255],
+            value_range=(0, 255),
             intercept=0,
             slope=1
         )
@@ -715,7 +715,7 @@ class TestParametricMap():
             lut_label='1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[0, 255],
+            value_range=(0, 255),
             intercept=0,
             slope=1
         )
@@ -804,7 +804,7 @@ class TestParametricMap():
             lut_label='1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[0, 255],
+            value_range=(0, 255),
             intercept=0,
             slope=1
         )
@@ -861,7 +861,7 @@ class TestParametricMap():
             lut_label='1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[0, 255],
+            value_range=(0, 255),
             intercept=0,
             slope=1
         )
@@ -886,6 +886,30 @@ class TestParametricMap():
         assert np.array_equal(pmap.pixel_array, pixel_array)
         assert hasattr(pmap, 'ExtendedOffsetTable')
         assert hasattr(pmap, 'ExtendedOffsetTableLengths')
+
+        # All frames
+        retrieved_pixels = pmap.get_pixels_by_source_frame(
+            source_sop_instance_uid=self._sm_image.SOPInstanceUID,
+        )
+        assert np.array_equal(retrieved_pixels, pixel_array)
+
+        # All frames (explicit)
+        retrieved_pixels = pmap.get_pixels_by_source_frame(
+            source_sop_instance_uid=self._sm_image.SOPInstanceUID,
+            source_frame_numbers=range(1, self._sm_image.NumberOfFrames + 1)
+        )
+        assert np.array_equal(retrieved_pixels, pixel_array)
+
+        # Subset of frames
+        retrieved_pixels = pmap.get_pixels_by_source_frame(
+            source_sop_instance_uid=self._sm_image.SOPInstanceUID,
+            source_frame_numbers=[4, 5, 6, 7],
+        )
+        assert np.array_equal(retrieved_pixels, pixel_array[3:7, ...])
+
+        msg = "The chosen dimensions do not uniquely identify frames of the "
+        with pytest.raises(RuntimeError, match=msg):
+            pmap.get_pixels_by_source_instance([self._sm_image.SOPInstanceUID])
 
     def test_single_frame_ct_image_double(self):
         pixel_array = np.random.uniform(-1, 1, self._ct_image.pixel_array.shape)
@@ -989,7 +1013,7 @@ class TestParametricMap():
             lut_label='1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[0, 4095],
+            value_range=(0, 4095),
             intercept=0,
             slope=1
         )
@@ -1080,7 +1104,7 @@ class TestParametricMap():
             lut_label='1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[0, 2**16],
+            value_range=(0, 2**16),
             intercept=-1,
             slope=2. / (2**16 - 1)
         )
@@ -1151,6 +1175,36 @@ class TestParametricMap():
         )
 
         assert np.array_equal(pmap.pixel_array, pixel_array)
+
+        instance_uids = [ds.SOPInstanceUID for ds in self._ct_series]
+        pixel_array_by_uid = pmap.get_pixels_by_source_instance(
+            source_sop_instance_uids=instance_uids,
+        )
+        assert np.array_equal(pixel_array_by_uid, pixel_array)
+
+        # Now try the same, reversed
+        instance_uids = list(reversed(instance_uids))
+        pixel_array_by_uid = pmap.get_pixels_by_source_instance(
+            source_sop_instance_uids=instance_uids,
+        )
+        flipped_pixel_array = np.flip(pixel_array_by_uid, axis=0)
+        assert np.array_equal(flipped_pixel_array, pixel_array)
+
+        msg = (
+            "Image does not record referenced frame numbers for the "
+            "given instance."
+        )
+        with pytest.raises(RuntimeError, match=msg):
+            pmap.get_pixels_by_source_frame(
+                source_sop_instance_uid=instance_uids[0],
+                source_frame_numbers=[1, 2],
+            )
+
+        with pytest.raises(KeyError):
+            pmap.get_pixels_by_source_frame(
+                source_sop_instance_uid="1.2.3.4",
+                source_frame_numbers=[1, 2],
+            )
 
     def test_multi_frame_sm_image_with_spatial_positions_not_preserved(self):
         pixel_array = np.random.randint(
@@ -1242,7 +1296,7 @@ class TestParametricMap():
             lut_label='1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[0, 255],
+            value_range=(0, 255),
             intercept=0,
             slope=1
         )
@@ -1366,7 +1420,7 @@ class TestParametricMap():
             lut_label='LUT1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[-10000.0, 10000.0],
+            value_range=(-10000.0, 10000.0),
             intercept=0,
             slope=1
         )
@@ -1374,7 +1428,7 @@ class TestParametricMap():
             lut_label='LUT2',
             lut_explanation='feature_002',
             unit=codes.UCUM.NoUnits,
-            value_range=[-10000.0, 10000.0],
+            value_range=(-10000.0, 10000.0),
             intercept=0,
             slope=1
         )
@@ -1506,7 +1560,7 @@ class TestParametricMap():
             lut_label='LUT1',
             lut_explanation='feature_001',
             unit=codes.UCUM.NoUnits,
-            value_range=[-10000.0, 10000.0],
+            value_range=(-10000.0, 10000.0),
             intercept=0,
             slope=1
         )
@@ -1514,7 +1568,7 @@ class TestParametricMap():
             lut_label='LUT2',
             lut_explanation='feature_002',
             unit=codes.UCUM.NoUnits,
-            value_range=[-10000.0, 10000.0],
+            value_range=(-10000.0, 10000.0),
             intercept=0,
             slope=1
         )

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -5001,6 +5001,21 @@ class TestSegmentationParsing:
         )
         assert pixels.shape == out_shape
 
+    def test_get_pixels_by_source_frames_all(self):
+        source_sop_uid = self._sm_control_seg.get_source_image_uids()[0][-1]
+
+        pixels = self._sm_control_seg.get_pixels_by_source_frame(
+            source_sop_instance_uid=source_sop_uid,
+        )
+
+        out_shape = (
+            25,
+            self._sm_control_seg.Rows,
+            self._sm_control_seg.Columns,
+            self._sm_control_seg.number_of_segments
+        )
+        assert pixels.shape == out_shape
+
     def test_get_pixels_by_invalid_source_frames(self):
         source_sop_uid = self._sm_control_seg.get_source_image_uids()[0][-1]
 


### PR DESCRIPTION
Add new methods for accessing pixels using source UIDs:

- Add `get_pixels_by_source_instance` and `get_pixels_by_source_frame` to the `highdicom.Image` class. Similar method already exist on the Segmentation class, but not the more general Image class. This is primarily motivated by the Parametric Map use case, but can be used on any image that contains per-frame references to source instances/frames.
- Add a specific `get_pixels_by_legacy_source_instance` method for Legacy Converted Enhanced classes that allow for retrieval of pixels using the conversion source information (i.e. SOP Instance UID of legacy instance)