### PR TITLE
Stricter spatial checks

### DIFF
--- a/src/highdicom/spatial.py
+++ b/src/highdicom/spatial.py
@@ -3917,15 +3917,15 @@ def get_volume_positions(
 
     # Additionally check that the vector from the first to the last plane lies
     # approximately along the normal vector
-    pos1 = unique_positions[sort_index[0], :]
-    pos2 = unique_positions[sort_index[-1], :]
-    span = (pos2 - pos1)
-    span /= np.linalg.norm(span)
+    spans = unique_positions[sort_index[1:]] - unique_positions[sort_index[0]]
+    spans /= np.linalg.norm(spans, axis=1)[:, None]
 
-    dot_product = normal_vector.T @ span
-    is_perpendicular = (
-        abs(dot_product - 1.0) < perpendicular_tol or
-        abs(dot_product + 1.0) < perpendicular_tol
+    dot_products = spans @ normal_vector
+    is_perpendicular = np.all(
+        np.logical_or(
+            np.abs(dot_products - 1.0) < perpendicular_tol,
+            np.abs(dot_products + 1.0) < perpendicular_tol
+        )
     )
 
     if not is_perpendicular:
@@ -3933,7 +3933,6 @@ def get_volume_positions(
             "Frame positions are not located along a vector "
             "normal to the image plane."
         )
-        logger.debug(f"Dot product: {dot_product:.4f}")
 
     if is_regular and is_perpendicular:
         vol_positions = [

--- a/src/highdicom/spatial.py
+++ b/src/highdicom/spatial.py
@@ -3915,8 +3915,8 @@ def get_volume_positions(
             )
             return None, None
 
-    # Additionally check that the vector from the first to the last plane lies
-    # approximately along the normal vector
+    # Additionally check that the vectors are all approximately along the
+    # normal vector
     spans = unique_positions[sort_index[1:]] - unique_positions[sort_index[0]]
     spans /= np.linalg.norm(spans, axis=1)[:, None]
 

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -1138,6 +1138,29 @@ def test_get_volume_positions_non_perpendicular():
             assert spacing is None
             assert volume_positions is None
 
+def test_get_volume_positions_non_perpendicular_2():
+    # Check that slices stacked along a vector that is not perpendicular to
+    # their normals (a "staircase") are not considered a volume
+    positions = [
+        [0.0, 0.0, 10.0],
+        [0.1, 0.0, 11.0],
+        [0.0, 0.0, 12.0],
+    ]
+    orientation = [1, 0, 0, 0, -1, 0]
+
+    # Regardless of values of allow_missing_positions and
+    # allow_duplicate_positions, this is not a volume
+    for allow_duplicate_positions in [False, True]:
+        for allow_missing_positions in [False, True]:
+            spacing, volume_positions = get_volume_positions(
+                positions,
+                orientation,
+                allow_missing_positions=allow_missing_positions,
+                allow_duplicate_positions=allow_duplicate_positions,
+            )
+            assert spacing is None
+            assert volume_positions is None
+
 
 def test_get_volume_positions_non_perpendicular_higher_tol():
     # Repeat above test with a higher tolerance so that the slices are

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -1138,6 +1138,7 @@ def test_get_volume_positions_non_perpendicular():
             assert spacing is None
             assert volume_positions is None
 
+
 def test_get_volume_positions_non_perpendicular_2():
     # Check that slices stacked along a vector that is not perpendicular to
     # their normals (a "staircase") are not considered a volume


### PR DESCRIPTION
In the `get_volume_positions` function, currently only the vector from first to last position is check to ensure it is perpendicular to the imaging plane. This PR implements the check on the first position to all other positions