### PR TITLE
Fix per-channel min-max normalization for 4-D volumes

### DIFF
--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -3428,7 +3428,7 @@ class Volume(_VolumeBase):
 
         if (
             per_channel and
-            self.number_of_channel_dimensions > 1
+            self.number_of_channel_dimensions > 0
         ):
             imin = self.array.min(axis=(0, 1, 2), keepdims=True)
             imax = self.array.max(axis=(0, 1, 2), keepdims=True)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1072,6 +1072,27 @@ def test_normalize():
     assert np.isclose(normed.array.max(), 1.0)
 
 
+def test_normalize_min_max_per_channel_single_dimension():
+    first_channel = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+    second_channel = 100.0 + 10.0 * first_channel
+    array = np.stack([first_channel, second_channel], axis=-1)
+    volume = Volume(
+        array,
+        np.eye(4),
+        coordinate_system="PATIENT",
+        channels={RGB_COLOR_CHANNEL_DESCRIPTOR: [
+            RGBColorChannels.R,
+            RGBColorChannels.G,
+        ]},
+    )
+    assert volume.number_of_channel_dimensions == 1
+
+    normalized = volume.normalize_min_max(per_channel=True)
+
+    assert np.allclose(normalized.array.min(axis=(0, 1, 2)), 0.0)
+    assert np.allclose(normalized.array.max(axis=(0, 1, 2)), 1.0)
+
+
 def test_normalize_uniform():
     # Normaliztion when std is zero
     arr = np.ones((10, 10, 10))


### PR DESCRIPTION
## Summary

- honor `per_channel=True` when a volume has exactly one channel dimension
- normalize each channel independently across the three spatial axes
- add regression coverage for channels with substantially different intensity ranges

## Root cause

`normalize_min_max()` enabled channel-wise reduction only when `number_of_channel_dimensions > 1`. A standard 4-D volume has exactly one channel dimension, so it silently fell back to global normalization despite the explicit option.

## Validation

- regression fails against `upstream/master`
- focused regression: 1 passed
- full `tests/test_volume.py`: 117 passed
- Flake8 on touched files
- `git diff --check`
