### PR TITLE
Preserve dtype in per-channel volume padding

### DIFF
--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -3646,7 +3646,10 @@ class Volume(_VolumeBase):
                 for s, (p1, p2) in zip(self.spatial_shape, full_pad_width)
             ]
             # preallocate output array
-            new_array = np.zeros([*out_spatial_shape, *self.channel_shape])
+            new_array = np.zeros(
+                [*out_spatial_shape, *self.channel_shape],
+                dtype=self.array.dtype,
+            )
             for cind in itertools.product(
                 *[range(n) for n in self.channel_shape]
             ):

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1040,6 +1040,33 @@ def test_pad_with_channels(mode, per_channel):
     assert padded.match_geometry(vol).geometry_equal(vol)
 
 
+@pytest.mark.parametrize('dtype', [np.uint16, np.float32])
+def test_pad_per_channel_preserves_dtype(dtype):
+    array = np.stack(
+        [
+            np.arange(1, 9).reshape(2, 2, 2),
+            np.arange(101, 109).reshape(2, 2, 2),
+        ],
+        axis=-1,
+    ).astype(dtype)
+    volume = Volume(
+        array,
+        np.eye(4),
+        coordinate_system="PATIENT",
+        channels={RGB_COLOR_CHANNEL_DESCRIPTOR: [
+            RGBColorChannels.R,
+            RGBColorChannels.G,
+        ]},
+    )
+
+    padded = volume.pad(1, mode=PadModes.MINIMUM, per_channel=True)
+
+    expected = np.full((4, 4, 4, 2), [1, 101], dtype=dtype)
+    expected[1:-1, 1:-1, 1:-1] = array
+    assert padded.array.dtype == dtype
+    assert np.array_equal(padded.array, expected)
+
+
 def test_pad_to_spatial_shape():
     vol, _ = read_multiframe_ct_volume()
 


### PR DESCRIPTION
## Summary

- preserve the source volume dtype when padding independently per channel
- add `uint16` and `float32` regression coverage
- verify distinct channel-wise minimum padding values and unchanged interior voxels

## Root cause

The per-channel padding path preallocated its output with `np.zeros()` without a dtype, which silently promoted all non-`float64` volumes to `float64`.

## Validation

- regression fails against `upstream/master` for both tested dtypes
- focused regression: 2 passed
- pad subset: 26 passed
- full `tests/test_volume.py`: 118 passed
- Flake8 on touched files
- `git diff --check`
