### PR TITLE
Validate ImageFileReader frame indices

### DIFF
--- a/src/highdicom/io.py
+++ b/src/highdicom/io.py
@@ -693,12 +693,18 @@ class ImageFileReader:
 
         Raises
         ------
+        ValueError
+            When `index` is less than 0 or greater than or equal to the number
+            of frames.
         OSError
             When frame could not be read
 
         """
-        if index > self.number_of_frames:
-            raise ValueError('Frame index exceeds number of frames in image.')
+        if index < 0 or index >= self.number_of_frames:
+            raise ValueError(
+                'Frame index must be greater than or equal to 0 and less '
+                'than the number of frames in the image.'
+            )
         logger.debug(f'read frame #{index}')
 
         frame_offset = self._offset_table[index]
@@ -751,6 +757,9 @@ class ImageFileReader:
 
         Raises
         ------
+        ValueError
+            When `index` is less than 0 or greater than or equal to the number
+            of frames.
         OSError
             When frame could not be read
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -39,6 +39,14 @@ class TestImageFileReader(unittest.TestCase):
             )
             np.testing.assert_array_equal(frame, pixel_array)
 
+    def test_reject_out_of_range_frame_indices(self):
+        filename = str(self._test_dir.joinpath('ct_image.dcm'))
+        with ImageFileReader(filename) as reader:
+            with pytest.raises(ValueError, match="Frame index"):
+                reader.read_frame_raw(-1)
+            with pytest.raises(ValueError, match="Frame index"):
+                reader.read_frame_raw(reader.number_of_frames)
+
     def test_read_multi_frame_ct_image_native(self):
         filename = str(get_testdata_file('eCT_Supplemental.dcm'))
         dataset = dcmread(filename)


### PR DESCRIPTION
## Summary

- reject negative frame indices and indices equal to `NumberOfFrames`
- validate before indexing the offset table or seeking into pixel data
- document the `ValueError` contract on raw and decoded frame access

## Root cause

The previous condition used `index > number_of_frames`. It therefore allowed Python negative indexing and missed the first invalid upper-bound value, `index == number_of_frames`.

## Validation

- regression fails on `upstream/master`
- focused regression: 1 passed
- full `tests/test_io.py`: 111 passed, 9 skipped
- Flake8 on touched files
- `git diff --check`
