### PR TITLE
Reject non-invertible volume affines

### DIFF
--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -272,9 +272,10 @@ class _VolumeBase(ABC):
         affine: numpy.ndarray
             4 x 4 affine matrix representing the transformation from voxel
             indices to the frame-of-reference coordinate system. The top left 3
-            x 3 matrix should be a scaled orthogonal matrix representing the
-            rotation and scaling. The top right 3 x 1 vector represents the
-            translation component. The last row should have value [0, 0, 0, 1].
+            x 3 matrix must be an invertible, scaled orthogonal matrix
+            representing the rotation and scaling. The top right 3 x 1 vector
+            represents the translation component. The last row should have
+            value [0, 0, 0, 1].
         coordinate_system: highdicom.CoordinateSystemNames | str
             Coordinate system (``"PATIENT"`` or ``"SLIDE"``) in which the volume
             is defined.
@@ -329,6 +330,13 @@ class _VolumeBase(ABC):
                     from_reference_convention=from_reference_convention,
                     to_reference_convention=LPS_PATIENT_REFERENCE_CONVENTION,
                 )
+
+        try:
+            np.linalg.inv(affine)
+        except np.linalg.LinAlgError as error:
+            raise ValueError(
+                "Argument 'affine' must be invertible."
+            ) from error
 
         self._affine = affine
         self._frame_of_reference_uid = frame_of_reference_uid
@@ -1990,9 +1998,10 @@ class VolumeGeometry(_VolumeBase):
             4 x 4 affine matrix representing the transformation from pixel
             indices (slice index, row index, column index) to the
             frame-of-reference coordinate system. The top left 3 x 3 matrix
-            should be a scaled orthogonal matrix representing the rotation and
-            scaling. The top right 3 x 1 vector represents the translation
-            component. The last row should have value [0, 0, 0, 1].
+            must be an invertible, scaled orthogonal matrix representing the
+            rotation and scaling. The top right 3 x 1 vector represents the
+            translation component. The last row should have value
+            [0, 0, 0, 1].
         spatial_shape: Sequence[int]
             Number of voxels in the (implied) volume along the three spatial
             dimensions.
@@ -2477,9 +2486,10 @@ class Volume(_VolumeBase):
             4 x 4 affine matrix representing the transformation from pixel
             indices (slice index, row index, column index) to the
             frame-of-reference coordinate system. The top left 3 x 3 matrix
-            should be a scaled orthogonal matrix representing the rotation and
-            scaling. The top right 3 x 1 vector represents the translation
-            component. The last row should have value [0, 0, 0, 1].
+            must be an invertible, scaled orthogonal matrix representing the
+            rotation and scaling. The top right 3 x 1 vector represents the
+            translation component. The last row should have value
+            [0, 0, 0, 1].
         coordinate_system: highdicom.CoordinateSystemNames | str
             Coordinate system (``"PATIENT"`` or ``"SLIDE"``) in which the volume
             is defined.

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -52,6 +52,26 @@ def read_ct_series_volume():
     return get_volume_from_series(ct_series), ct_series
 
 
+@pytest.mark.parametrize('volume_type', [Volume, VolumeGeometry])
+def test_reject_singular_affine(volume_type):
+    affine = np.eye(4)
+    # Keep the dependent column non-zero so that the approximate
+    # orthogonality check alone does not reject the affine.
+    affine[:3, 2] = affine[:3, 0] * 1e-6
+
+    kwargs = {
+        'affine': affine,
+        'coordinate_system': "PATIENT",
+    }
+    if volume_type is Volume:
+        kwargs['array'] = np.zeros((2, 2, 2))
+    else:
+        kwargs['spatial_shape'] = (2, 2, 2)
+
+    with pytest.raises(ValueError, match="affine.*invertible"):
+        volume_type(**kwargs)
+
+
 def test_transforms():
     array = np.zeros((25, 50, 50))
     orientation = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]


### PR DESCRIPTION
## Summary

- reject non-invertible affine matrices during `Volume` and `VolumeGeometry` construction
- retain the existing scaled-orthogonality and final-row validation
- clarify the constructor contract and add coverage for both public types

## Root cause

The approximate orthogonality check can accept rank-deficient matrices whose dependent column is sufficiently small. Those objects then fail later when spatial operations attempt to invert the affine.

## Validation

- regression fails for both constructors on `upstream/master`
- focused regression: 2 passed
- full `tests/test_volume.py`: 118 passed
- Flake8 on touched files
- `git diff --check`
