### PR TITLE
Fix per-channel min-max normalization for 4-D volumes

### DIFF
--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -3428,7 +3428,7 @@ class Volume(_VolumeBase):
 
         if (
             per_channel and
-            self.number_of_channel_dimensions > 1
+            self.number_of_channel_dimensions > 0
         ):
             imin = self.array.min(axis=(0, 1, 2), keepdims=True)
             imax = self.array.max(axis=(0, 1, 2), keepdims=True)

--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -3438,11 +3438,11 @@ class Volume(_VolumeBase):
 
             peak_to_peak = imax - imin
 
-            # Avoid division by zero without assigning a fractional output
-            # range into an integer array.
+            # Constant channels map to output_min; keep their inert scale at
+            # 1.0 while avoiding division by zero.
             safe_peak_to_peak = np.where(
                 peak_to_peak == 0.0,
-                1,
+                output_range,
                 peak_to_peak,
             )
             scale_factor = output_range / safe_peak_to_peak

--- a/src/highdicom/volume.py
+++ b/src/highdicom/volume.py
@@ -3432,12 +3432,20 @@ class Volume(_VolumeBase):
         ):
             imin = self.array.min(axis=(0, 1, 2), keepdims=True)
             imax = self.array.max(axis=(0, 1, 2), keepdims=True)
+            if np.issubdtype(self.array.dtype, np.integer):
+                imin = imin.astype(np.float64)
+                imax = imax.astype(np.float64)
 
             peak_to_peak = imax - imin
 
-            # Avoid division by zerp
-            peak_to_peak[peak_to_peak == 0.0] = output_range
-            scale_factor = output_range / peak_to_peak
+            # Avoid division by zero without assigning a fractional output
+            # range into an integer array.
+            safe_peak_to_peak = np.where(
+                peak_to_peak == 0.0,
+                1,
+                peak_to_peak,
+            )
+            scale_factor = output_range / safe_peak_to_peak
         else:
             imin = self.array.min()
             imax = self.array.max()

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1108,15 +1108,15 @@ def test_normalize_min_max_per_channel_constant_integer_channel():
     )
 
     normalized = volume.normalize_min_max(
-        output_min=0.0,
-        output_max=0.5,
+        output_min=-2.0,
+        output_max=3.0,
         per_channel=True,
     )
 
     assert np.isfinite(normalized.array).all()
-    assert np.allclose(normalized.array[..., 0], 0.0)
-    assert np.isclose(normalized.array[..., 1].min(), 0.0)
-    assert np.isclose(normalized.array[..., 1].max(), 0.5)
+    assert np.allclose(normalized.array[..., 0], -2.0)
+    assert np.isclose(normalized.array[..., 1].min(), -2.0)
+    assert np.isclose(normalized.array[..., 1].max(), 3.0)
 
 
 def test_normalize_min_max_per_channel_signed_integer_range():

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1093,6 +1093,56 @@ def test_normalize_min_max_per_channel_single_dimension():
     assert np.allclose(normalized.array.max(axis=(0, 1, 2)), 1.0)
 
 
+def test_normalize_min_max_per_channel_constant_integer_channel():
+    first_channel = np.full((2, 2, 2), 7, dtype=np.uint16)
+    second_channel = np.arange(8, dtype=np.uint16).reshape(2, 2, 2)
+    array = np.stack([first_channel, second_channel], axis=-1)
+    volume = Volume(
+        array,
+        np.eye(4),
+        coordinate_system="PATIENT",
+        channels={RGB_COLOR_CHANNEL_DESCRIPTOR: [
+            RGBColorChannels.R,
+            RGBColorChannels.G,
+        ]},
+    )
+
+    normalized = volume.normalize_min_max(
+        output_min=0.0,
+        output_max=0.5,
+        per_channel=True,
+    )
+
+    assert np.isfinite(normalized.array).all()
+    assert np.allclose(normalized.array[..., 0], 0.0)
+    assert np.isclose(normalized.array[..., 1].min(), 0.0)
+    assert np.isclose(normalized.array[..., 1].max(), 0.5)
+
+
+def test_normalize_min_max_per_channel_signed_integer_range():
+    first_channel = np.array(
+        [-32768, -24576, -16384, -8192, 0, 8192, 16384, 32767],
+        dtype=np.int16,
+    ).reshape(2, 2, 2)
+    second_channel = np.arange(8, dtype=np.int16).reshape(2, 2, 2)
+    array = np.stack([first_channel, second_channel], axis=-1)
+    volume = Volume(
+        array,
+        np.eye(4),
+        coordinate_system="PATIENT",
+        channels={RGB_COLOR_CHANNEL_DESCRIPTOR: [
+            RGBColorChannels.R,
+            RGBColorChannels.G,
+        ]},
+    )
+
+    normalized = volume.normalize_min_max(per_channel=True)
+
+    assert np.isfinite(normalized.array).all()
+    assert np.allclose(normalized.array.min(axis=(0, 1, 2)), 0.0)
+    assert np.allclose(normalized.array.max(axis=(0, 1, 2)), 1.0)
+
+
 def test_normalize_uniform():
     # Normaliztion when std is zero
     arr = np.ones((10, 10, 10))

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1072,6 +1072,27 @@ def test_normalize():
     assert np.isclose(normed.array.max(), 1.0)
 
 
+def test_normalize_min_max_per_channel_single_dimension():
+    first_channel = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+    second_channel = 100.0 + 10.0 * first_channel
+    array = np.stack([first_channel, second_channel], axis=-1)
+    volume = Volume(
+        array,
+        np.eye(4),
+        coordinate_system="PATIENT",
+        channels={RGB_COLOR_CHANNEL_DESCRIPTOR: [
+            RGBColorChannels.R,
+            RGBColorChannels.G,
+        ]},
+    )
+    assert volume.number_of_channel_dimensions == 1
+
+    normalized = volume.normalize_min_max(per_channel=True)
+
+    assert np.allclose(normalized.array.min(axis=(0, 1, 2)), 0.0)
+    assert np.allclose(normalized.array.max(axis=(0, 1, 2)), 1.0)
+
+
 def test_normalize_uniform():
     # Normaliztion when std is zero
     arr = np.ones((10, 10, 10))


### PR DESCRIPTION
Closes #437.

## Summary

- honor `per_channel=True` when a volume has exactly one channel dimension
- normalize each channel independently across the three spatial axes
- make integer extrema/range arithmetic safe for constant and full-range channels
- add float32, constant-`uint16`, and full-range-`int16` regression coverage

## Root cause

`normalize_min_max()` enabled channel-wise reduction only when `number_of_channel_dimensions > 1`. In addition, its zero-range workaround wrote a possibly fractional output range into the input-typed peak-to-peak array, and signed integer subtraction could overflow before promotion.

## Validation

- all three regressions fail on the relevant pre-fix implementation
- repository-documented `pytest --flake8`: 2,023 passed, 179 expected optional-codec skips
- `git diff --check`
