### PR TITLE
Various bugfixes and tests related to LUTs

### DIFF
--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -31,7 +31,9 @@ from highdicom.enum import (
 )
 from highdicom.pixels import (
     _check_rescale_dtype,
+    _expand_segmented_lut,
     _get_combined_palette_color_lut,
+    _get_expanded_lut_length,
     _parse_palette_color_lut_attributes,
     _select_voi_lut,
     _select_voi_window_center_width,
@@ -2990,6 +2992,7 @@ class PaletteColorLUT(Dataset):
             setattr(new_ds, kw, getattr(dataset, kw))
 
         new_ds.__class__ = cls
+        new_ds._lut_data = None
         return cast(Self, new_ds)
 
 
@@ -3084,54 +3087,7 @@ class SegmentedPaletteColorLUT(Dataset):
             segmented_lut_data.tobytes()
         )
 
-        expanded_lut_values = []
-        i = 0
-        offset = 0
-        while i < len(segmented_lut_data):
-            opcode = segmented_lut_data[i]
-            i += 1
-            if opcode == 0:
-                # Discrete segment type (constant)
-                length = segmented_lut_data[i]
-                i += 1
-                value = segmented_lut_data[i]
-                i += 1
-                expanded_lut_values.extend([
-                    value for _ in range(length)
-                ])
-                offset += length
-            elif opcode == 1:
-                # Linear segment type (interpolation)
-                length = segmented_lut_data[i]
-                i += 1
-                start_value = expanded_lut_values[offset - 1]
-                end_value = segmented_lut_data[i]
-                i += 1
-                step = (end_value - start_value) / (length - 1)
-                expanded_lut_values.extend([
-                    start_value + int(np.round(j * step))
-                    for j in range(length)
-
-                ])
-                offset += length
-            elif opcode == 2:
-                # TODO
-                raise ValueError(
-                  'Indirect segment type is not yet supported for '
-                  'Segmented Palette Color Lookup Table.'
-                )
-            else:
-                raise ValueError(
-                  f'Encountered unexpected segment type {opcode} for '
-                  'Segmented Palette Color Lookup Table.'
-                )
-
-        self._lut_data = np.array(
-            expanded_lut_values,
-            dtype=segmented_lut_data.dtype,
-        )
-
-        len_data = len(expanded_lut_values)
+        len_data = _get_expanded_lut_length(segmented_lut_data)
         if len_data == 2 ** 16:
             number_of_entries = 0
         else:
@@ -3145,7 +3101,6 @@ class SegmentedPaletteColorLUT(Dataset):
     @property
     def segmented_lut_data(self) -> np.ndarray:
         """numpy.ndarray: segmented lookup table data"""
-        length = self.number_of_entries
         data = getattr(self, f'Segmented{self._attr_name_prefix}Data')
         if self.bits_per_entry == 8:
             dtype = np.uint8
@@ -3153,19 +3108,13 @@ class SegmentedPaletteColorLUT(Dataset):
             dtype = np.uint16
         else:
             raise RuntimeError("Invalid LUT descriptor.")
-        # The LUT data attributes have VR OW (16-bit other words)
-        array = np.frombuffer(data, dtype=dtype)
-        if len(array) != length:
-            raise RuntimeError(
-                'Length of LUTData does not match the value expected from the '
-                f'LUTDescriptor. Expected {length}, found {len(array)}.'
-            )
-        return array
+
+        return np.frombuffer(data, dtype=dtype)
 
     @property
     def lut_data(self) -> np.ndarray:
         """numpy.ndarray: expanded lookup table data"""
-        return self._lut_data
+        return _expand_segmented_lut(self.segmented_lut_data)
 
     @property
     def number_of_entries(self) -> int:
@@ -3195,6 +3144,37 @@ class SegmentedPaletteColorLUT(Dataset):
         """int: Bits allocated for the lookup table data. 8 or 16."""
         descriptor = getattr(self, f'{self._attr_name_prefix}Descriptor')
         return int(descriptor[2])
+
+    def apply(
+        self,
+        array: np.ndarray,
+        dtype: type | str | np.dtype | None = None,
+    ) -> np.ndarray:
+        """Apply the LUT to a pixel array.
+
+        Parameters
+        ----------
+        apply: numpy.ndarray
+            Pixel array to which the LUT should be applied. Can be of any shape
+            but must have an integer datatype.
+        dtype: Union[type, str, numpy.dtype, None], optional
+            Datatype of the output array. If ``None``, an unsigned integer
+            datatype corresponding to the number of bits in the LUT will be
+            used (either ``numpy.uint8`` or ``numpy.uint16``). Only safe casts
+            are permitted.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array with LUT applied.
+
+        """
+        return apply_lut(
+            array=array,
+            lut_data=self.lut_data,
+            first_mapped_value=self.first_mapped_value,
+            dtype=dtype,
+        )
 
     @classmethod
     def extract_from_dataset(cls, dataset: Dataset, color: str) -> Self:
@@ -3640,7 +3620,12 @@ class PaletteColorLUTTransformation(Dataset):
                 data_kw = f'{color}PaletteColorLookupTableData'
             setattr(new_dataset, data_kw, data)
 
+        uid = dataset.get('PaletteColorLookupTableUID')
+        if uid is not None:
+            new_dataset.PaletteColorLookupTableUID = uid
+
         new_dataset.__class__ = cls
+        new_dataset._lut_data = None
         return cast(Self, new_dataset)
 
     def apply(

--- a/src/highdicom/pixels.py
+++ b/src/highdicom/pixels.py
@@ -40,8 +40,10 @@ def _parse_palette_color_lut_attributes(dataset: Dataset) -> tuple[
     """
     is_segmented = 'SegmentedRedPaletteColorLookupTableData' in dataset
 
-    if not is_segmented:
-        if 'RedPaletteColorLookupTableData' not in dataset:
+    if (
+        not is_segmented
+        and 'RedPaletteColorLookupTableData' not in dataset
+    ):
             raise AttributeError(
                 'Dataset does not contain palette color lookup table '
                 'attributes.'
@@ -107,7 +109,7 @@ def _parse_palette_color_lut_attributes(dataset: Dataset) -> tuple[
             )
 
         lut_bytes = getattr(dataset, data_kw)
-        if len(lut_bytes) != expected_num_bytes:
+        if not is_segmented and len(lut_bytes) != expected_num_bytes:
             raise RuntimeError(
                 "LUT data has incorrect length"
             )
@@ -476,6 +478,114 @@ def apply_voi_window(
         ) + output_min
 
     return array
+
+
+def _expand_segmented_lut(
+    segmented_lut_data: np.ndarray
+) -> np.ndarray:
+    """Expand segmented LUT data to "standard" LUT representation.
+
+    Parameters
+    ----------
+    segmented_lut_data: numpy.ndarray
+        Segmented LUT data (consisting of opcodes and parameters) as a 1D numpy
+        array with dtype uint8 or uint16.
+
+    Returns
+    -------
+    numpy.ndarray:
+        Expanded representation of the segmented lut data. 1D numpy array with
+        the same dtype as the input array.
+
+    """
+    expanded_lut_values = []
+    i = 0
+    while i < len(segmented_lut_data):
+        opcode = segmented_lut_data[i]
+        if opcode == 0:
+            # Discrete segment type (literal)
+            length = segmented_lut_data[i + 1]
+            expanded_lut_values.extend(
+                segmented_lut_data[i + 2:i + 2 + length].tolist()
+            )
+            i += (length + 2)
+        elif opcode == 1:
+            # Linear segment type (interpolation)
+            length = segmented_lut_data[i + 1]
+
+            # Need signed integers for subsequent calculations
+            start_value = int(expanded_lut_values[-1])
+            end_value = int(segmented_lut_data[i + 2])
+            step = (end_value - start_value) / length
+
+            expanded_lut_values.extend([
+                start_value + int(np.round(j * step))
+                for j in range(1, length + 1)
+            ])
+            i += 3
+        elif opcode == 2:
+            # TODO
+            raise ValueError(
+                'Indirect segment type is not yet supported for '
+                'Segmented Palette Color Lookup Table.'
+            )
+        else:
+            raise ValueError(
+                f'Encountered unexpected segment type {opcode} for '
+                'Segmented Palette Color Lookup Table.'
+            )
+
+    return np.array(expanded_lut_values, dtype=segmented_lut_data.dtype)
+
+
+def _get_expanded_lut_length(
+    segmented_lut_data: np.ndarray
+) -> int:
+    """Get length of expanded segmented LUT data.
+
+    This function does not expand the array to calculate the total length, and
+    is thus much more memory efficient than _expand_segmented_lut if only the
+    length is needed.
+
+    Parameters
+    ----------
+    segmented_lut_data: numpy.ndarray
+        Segmented LUT data (consisting of opcodes and parameters) as a 1D numpy
+        array with dtype uint8 or uint16.
+
+    Returns
+    -------
+    int:
+        Length (number of entries) of the expanded data.
+
+    """
+    total_length = 0
+    i = 0
+    while i < len(segmented_lut_data):
+        opcode = segmented_lut_data[i]
+        if opcode == 0:
+            # Discrete segment type (literal)
+            length = segmented_lut_data[i + 1]
+            total_length += length
+            i += (length + 2)
+        elif opcode == 1:
+            # Linear segment type (interpolation)
+            length = segmented_lut_data[i + 1]
+            total_length += length
+            i += 3
+        elif opcode == 2:
+            # TODO
+            raise ValueError(
+                'Indirect segment type is not yet supported for '
+                'Segmented Palette Color Lookup Table.'
+            )
+        else:
+            raise ValueError(
+                f'Encountered unexpected segment type {opcode} for '
+                'Segmented Palette Color Lookup Table.'
+            )
+
+    return int(total_length)
 
 
 def apply_lut(

--- a/src/highdicom/pixels.py
+++ b/src/highdicom/pixels.py
@@ -41,13 +41,13 @@ def _parse_palette_color_lut_attributes(dataset: Dataset) -> tuple[
     is_segmented = 'SegmentedRedPaletteColorLookupTableData' in dataset
 
     if (
-        not is_segmented
-        and 'RedPaletteColorLookupTableData' not in dataset
+        not is_segmented and
+        'RedPaletteColorLookupTableData' not in dataset
     ):
-            raise AttributeError(
-                'Dataset does not contain palette color lookup table '
-                'attributes.'
-            )
+        raise AttributeError(
+            'Dataset does not contain palette color lookup table '
+            'attributes.'
+        )
 
     descriptor = dataset.RedPaletteColorLookupTableDescriptor
     if len(descriptor) != 3:

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -27,6 +27,7 @@ from highdicom import (
     PlanePositionSequence,
     ReferencedImageSequence,
     RescaleTypeValues,
+    SegmentedPaletteColorLUT,
     SpecimenCollection,
     SpecimenDescription,
     SpecimenPreparationStep,
@@ -1998,6 +1999,202 @@ class TestPaletteColorLUT(TestCase):
             with pytest.raises(TypeError):
                 lut.apply(arr, dtype=dtype)
 
+    def test_extract_from_dataset(self):
+        for dtype in [np.uint8, np.uint16]:
+            for color in ['red', 'green', 'blue']:
+                lut_data = np.arange(0, 256, dtype=dtype)
+                first_mapped_value = 0
+                lut = PaletteColorLUT(first_mapped_value, lut_data, color=color)
+
+                # Create a "plain" pydicom dataset containing the same
+                # attributes
+                ds = Dataset()
+
+                for k, v in lut.items():
+                    ds[k] = v
+
+                extracted = PaletteColorLUT.extract_from_dataset(
+                    ds,
+                    color=color
+                )
+                assert extracted == lut
+                assert np.array_equal(lut.lut_data, lut_data)
+
+
+class TestSegmentedPaletteColorLUT(TestCase):
+
+    def test_construction_16bit(self):
+        segmented_lut_data = np.array(
+            [
+                0, 3, 4, 5, 6,  # literal [4, 5, 6]
+                1, 3, 0,  # ramp down to zero in 3 steps [4, 2, 0]
+                0, 2, 10, 20,  # literal [10, 20]
+                1, 4, 40,  # ramp up to 40 in 4 steps [25, 30, 35, 40]
+            ],
+            dtype=np.uint16
+        )
+
+        # The expected expansion of the above
+        lut_data = np.array(
+            [4, 5, 6, 4, 2, 0, 10, 20, 25, 30, 35, 40],
+            dtype=np.uint16,
+        )
+
+        first_mapped_value = 32
+        lut = SegmentedPaletteColorLUT(
+            first_mapped_value,
+            segmented_lut_data,
+            color='red'
+        )
+
+        assert len(lut.RedPaletteColorLookupTableDescriptor) == 3
+        assert lut.RedPaletteColorLookupTableDescriptor[0] == len(lut_data)
+        assert lut.RedPaletteColorLookupTableDescriptor[1] == 32
+        assert lut.RedPaletteColorLookupTableDescriptor[2] == 16
+        assert not hasattr(lut, 'BluePaletteColorLookupTableDescriptor')
+        assert not hasattr(lut, 'GreenPaletteColorLookupTableDescriptor')
+        assert len(lut.SegmentedRedPaletteColorLookupTableData) == (
+            segmented_lut_data.shape[0] * 2
+        )
+        assert not hasattr(lut, 'SegmentedBluePaletteColorLookupTableData')
+        assert not hasattr(lut, 'SegmentedGreenPaletteColorLookupTableData')
+
+        assert lut.number_of_entries == lut_data.shape[0]
+        assert lut.first_mapped_value == first_mapped_value
+        assert lut.bits_per_entry == 16
+        assert lut.lut_data.dtype == np.uint16
+        np.array_equal(lut.segmented_lut_data, segmented_lut_data)
+        np.array_equal(lut.lut_data, lut_data)
+
+        arr = np.array([32, 33, 32, 38, 41])
+        expected = np.array([4, 5, 4, 10, 30])
+        output = lut.apply(arr)
+        assert output.dtype == np.uint16
+        assert np.array_equal(output, expected)
+
+        for dtype in [
+            np.uint16,
+            np.uint32,
+            np.float32,
+            np.float64,
+            np.int32,
+            np.int64,
+        ]:
+            output = lut.apply(arr, dtype=dtype)
+            assert output.dtype == dtype
+            assert np.array_equal(output, expected.astype(dtype))
+
+        for dtype in [
+            np.uint8,
+            np.int8,
+            np.int16,
+        ]:
+            with pytest.raises(TypeError):
+                lut.apply(arr, dtype=dtype)
+
+    def test_construction_8bit(self):
+        segmented_lut_data = np.array(
+            [
+                0, 3, 4, 5, 6,  # literal [4, 5, 6]
+                1, 3, 0,  # ramp down to zero in 3 steps [4, 2, 0]
+                0, 2, 10, 20,  # literal [10, 20]
+                1, 4, 40,  # ramp up to 40 in 4 steps [25, 30, 35, 40]
+            ],
+            dtype=np.uint8
+        )
+
+        # The expected expansion of the above
+        lut_data = np.array(
+            [4, 5, 6, 4, 2, 0, 10, 20, 25, 30, 35, 40],
+            dtype=np.uint8,
+        )
+        first_mapped_value = 0
+        lut = SegmentedPaletteColorLUT(
+            first_mapped_value,
+            segmented_lut_data,
+            color='blue',
+        )
+
+        assert len(lut.BluePaletteColorLookupTableDescriptor) == 3
+        assert lut.BluePaletteColorLookupTableDescriptor[0] == len(lut_data)
+        assert lut.BluePaletteColorLookupTableDescriptor[1] == 0
+        assert lut.BluePaletteColorLookupTableDescriptor[2] == 8
+        assert not hasattr(lut, 'RedPaletteColorLookupTableDescriptor')
+        assert not hasattr(lut, 'GreenPaletteColorLookupTableDescriptor')
+        expected_len = segmented_lut_data.shape[0]
+        assert len(lut.SegmentedBluePaletteColorLookupTableData) == expected_len
+        assert not hasattr(lut, 'SegmentedRedPaletteColorLookupTableData')
+        assert not hasattr(lut, 'SegmentedGreenPaletteColorLookupTableData')
+
+        assert lut.number_of_entries == lut_data.shape[0]
+        assert lut.first_mapped_value == first_mapped_value
+        assert lut.bits_per_entry == 8
+        assert lut.lut_data.dtype == np.uint8
+        np.array_equal(lut.lut_data, lut_data)
+
+        arr = np.array([0, 1, 0, 6, 9])
+        expected = np.array([4, 5, 4, 10, 30])
+        output = lut.apply(arr)
+        assert output.dtype == np.uint8
+        assert np.array_equal(output, expected)
+
+        for dtype in [
+            np.uint16,
+            np.uint32,
+            np.int16,
+            np.float32,
+            np.float64,
+            np.int32,
+            np.int64,
+        ]:
+            output = lut.apply(arr, dtype=dtype)
+            assert output.dtype == dtype
+            assert np.array_equal(output, expected.astype(dtype))
+
+        for dtype in [
+            np.int8,
+        ]:
+            with pytest.raises(TypeError):
+                lut.apply(arr, dtype=dtype)
+
+    def test_extract_from_dataset(self):
+        for dtype in [np.uint8, np.uint16]:
+            for color in ['red', 'green', 'blue']:
+                segmented_lut_data = np.array(
+                    [
+                        0, 3, 4, 5, 6,  # literal [4, 5, 6]
+                        1, 3, 0,  # ramp down to zero in 3 steps [4, 2, 0]
+                        0, 2, 10, 20,  # literal [10, 20]
+                        1, 4, 40,  # ramp up to 40 in 4 steps [25, 30, 35, 40]
+                    ],
+                    dtype=np.uint8
+                )
+                # the expected expansion of the above
+                lut_data = np.array(
+                    [4, 5, 6, 4, 2, 0, 10, 20, 25, 30, 35, 40],
+                    dtype=np.uint8,
+                )
+                first_mapped_value = 0
+                lut = SegmentedPaletteColorLUT(
+                    first_mapped_value,
+                    segmented_lut_data,
+                    color=color
+                 )
+
+                # Create a "plain" pydicom dataset containing the same
+                # attributes
+                ds = Dataset()
+
+                for k, v in lut.items():
+                    ds[k] = v
+
+                extracted = SegmentedPaletteColorLUT.extract_from_dataset(
+                    ds,
+                    color=color,
+                 )
+                assert extracted == lut
+                assert np.array_equal(lut.lut_data, lut_data)
+
 
 class TestPaletteColorLUTTransformation(TestCase):
 
@@ -2168,6 +2365,51 @@ class TestPaletteColorLUTTransformation(TestCase):
         assert np.array_equal(lut.red_lut.lut_data, r_lut_data)
         assert np.array_equal(lut.blue_lut.lut_data, b_lut_data)
         assert np.array_equal(lut.green_lut.lut_data, g_lut_data)
+
+    def test_extract_from_dataset(self):
+        for bits, dtype in [(8, np.uint8), (16, np.uint16)]:
+            r_lut_data = np.arange(10, 120, dtype=dtype)
+            g_lut_data = np.arange(20, 130, dtype=dtype)
+            b_lut_data = np.arange(30, 140, dtype=dtype)
+            first_mapped_value = 32
+            lut_uid = UID()
+            r_lut = PaletteColorLUT(
+                first_mapped_value,
+                r_lut_data,
+                color='red',
+            )
+            g_lut = PaletteColorLUT(
+                first_mapped_value,
+                g_lut_data,
+                color='green',
+            )
+            b_lut = PaletteColorLUT(
+                first_mapped_value,
+                b_lut_data,
+                color='blue',
+            )
+            combined_lut_data = np.stack(
+                [r_lut_data, g_lut_data, b_lut_data]
+            ).T
+            instance = PaletteColorLUTTransformation(
+                red_lut=r_lut,
+                green_lut=g_lut,
+                blue_lut=b_lut,
+                palette_color_lut_uid=lut_uid,
+            )
+
+            # Create a "plain" pydicom dataset containing the same attributes
+            ds = Dataset()
+
+            for k, v in instance.items():
+                ds[k] = v
+
+            extracted = PaletteColorLUTTransformation.extract_from_dataset(ds)
+            assert extracted == instance
+            assert np.array_equal(
+                instance.combined_lut_data,
+                combined_lut_data,
+            )
 
 
 class TestSpecimenDescription(TestCase):


### PR DESCRIPTION
Various bugfixes related to LUTs:

- The `extract_from_dataset` methods did not set the `_lut_data` cache property, meaning that trying extracted lut data from the returned objects resulting in an exception
- The segmented LUT expansion code was overcomplicated and wrong in multiple ways:
  - The interpretation of the discrete segment assumed a single constant value repeated, whereas this should be a set with arbitrary length of literal values that is not repeated in the output array
  - The linear segment expansion repeated the last value of the previous segment and could not deal correctly with negative slopes due to use of unsigned integers
 - Construction of a segmented lut involved expanding the entire array, which is rather memory intensive. This is replaced with a method that finds the length without full expansion
 - SegmentedPaletteColorLUt now has an `apply` method (this is the only API change)
 - Expanded test coverage