### PR TITLE
Improve description of tracking (U)ID

### DIFF
--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -77,9 +77,13 @@ class SegmentDescription(Dataset):
             Information useful for identification of the algorithm, such
             as its name or version. Required unless the algorithm type is `MANUAL`
         tracking_uid: Union[str, None], optional
-            Unique tracking identifier (universally unique)
+            Unique tracking identifier (universally unique). This is intended
+            to provide an identifier to track this segment across multiple
+            imaging studies.
         tracking_id: Union[str, None], optional
-            Tracking identifier (unique only with the domain of use)
+            Tracking identifier (unique only with the domain of use). This is
+            intended to provide an identifier to track this segment across
+            multiple imaging studies.
         anatomic_regions: Union[Sequence[Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept]], None], optional
             Anatomic region(s) into which segment falls,
             e.g. ``Code("41216001", "SCT", "Prostate")``

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -776,7 +776,12 @@ class AlgorithmIdentification(Template):
 
 class TrackingIdentifier(Template):
 
-    """:dcm:`TID 4108 <part16/sect_TID_4108.html>` Tracking Identifier"""
+    """:dcm:`TID 4108 <part16/sect_TID_4108.html>` Tracking Identifier
+
+    Identifier used to track a single region of interest across multiple
+    images or imaging studies.
+
+    """
 
     def __init__(
         self,
@@ -2479,7 +2484,8 @@ class Measurement(Template):
             Qualification of numeric measurement value or as an alternative
             qualitative description
         tracking_identifier: Union[highdicom.sr.TrackingIdentifier, None], optional
-            Identifier for tracking measurements
+            Identifier for tracking measurements across multiple images or
+            imaging studies.
         algorithm_id: Union[highdicom.sr.AlgorithmIdentification, None], optional
             Identification of algorithm used for making measurements
         derivation: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code, None], optional
@@ -2776,7 +2782,8 @@ class _MeasurementsAndQualitativeEvaluations(Template):
         Parameters
         ----------
         tracking_identifier: highdicom.sr.TrackingIdentifier
-            Identifier for tracking measurements
+            Identifier for tracking measurements across multiple images or
+            imaging studies.
         referenced_real_world_value_map: Union[highdicom.sr.RealWorldValueMap, None], optional
             Referenced real world value map for region of interest
         time_point_context: Union[highdicom.sr.TimePointContext, None], optional
@@ -3176,7 +3183,8 @@ class MeasurementsAndQualitativeEvaluations(
         Parameters
         ----------
         tracking_identifier: highdicom.sr.TrackingIdentifier
-            Identifier for tracking measurements
+            Identifier for tracking measurements across multiple images or
+            imaging studies.
         referenced_real_world_value_map: Union[highdicom.sr.RealWorldValueMap, None], optional
             Referenced real world value map for region of interest
         time_point_context: Union[highdicom.sr.TimePointContext, None], optional
@@ -3296,7 +3304,8 @@ class _ROIMeasurementsAndQualitativeEvaluations(
         Parameters
         ----------
         tracking_identifier: highdicom.sr.TrackingIdentifier
-            Identifier for tracking measurements
+            Identifier for tracking regions of interest across multiple images
+            or imaging studies.
         referenced_regions: Union[Sequence[highdicom.sr.ImageRegion], Sequence[highdicom.sr.ImageRegion3D], None], optional
             Regions of interest in source image(s)
         referenced_segment: Union[highdicom.sr.ReferencedSegment, highdicom.sr.ReferencedSegmentationFrame, None], optional
@@ -3458,7 +3467,8 @@ class PlanarROIMeasurementsAndQualitativeEvaluations(
         Parameters
         ----------
         tracking_identifier: highdicom.sr.TrackingIdentifier
-            Identifier for tracking measurements
+            Identifier for tracking regions of interest across multiple images
+            or imaging studies.
         referenced_region: Union[highdicom.sr.ImageRegion, highdicom.sr.ImageRegion3D, None], optional
             Region of interest in source image
         referenced_segment: Union[highdicom.sr.ReferencedSegmentationFrame, None], optional
@@ -3741,7 +3751,8 @@ class VolumetricROIMeasurementsAndQualitativeEvaluations(
         Parameters
         ----------
         tracking_identifier: highdicom.sr.TrackingIdentifier
-            Identifier for tracking measurements
+            Identifier for tracking regions of interest across multiple images
+            or imaging studies.
         referenced_regions: Union[Sequence[highdicom.sr.ImageRegion], None], optional
             Regions of interest in source image(s)
         referenced_volume_surface: Union[highdicom.sr.VolumeSurface, None], optional


### PR DESCRIPTION
Addresses #459 

The tracking ID is already described in SR and SEG pages of the User Guide, but this PR improves the docstrings in the API reference to make it clearer that tracking IDs are used to track ROIs across imaging studies. 